### PR TITLE
Force version, update pub uploaders

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -29,7 +29,7 @@ class Generator {
     _clientVersionBuild = 0;
   }
 
-  bool generateClient(String outputDirectory, {bool fullLibrary: false, bool check: false, bool force: false}) {
+  bool generateClient(String outputDirectory, {bool fullLibrary: false, bool check: false, bool force: false, int forceVersion}) {
     var mainFolder, srcFolder, libFolder;
     if (fullLibrary) {
       mainFolder = outputDirectory;
@@ -56,7 +56,7 @@ class Generator {
         if (force) {
           print("Forced rebuild");
           print("Regenerating library $_libraryName");
-          _clientVersionBuild = int.parse(version.substring(clientVersion.length + 1)) + 1;
+          _clientVersionBuild = (forceVersion != null) ? forceVersion : int.parse(version.substring(clientVersion.length + 1)) + 1;
         } else {
           if (version.startsWith(clientVersion)) {
             if (etag == _json["etag"]) {
@@ -65,18 +65,18 @@ class Generator {
             } else {
               print("Changes for $_libraryName");
               print("Regenerating library $_libraryName");
-              _clientVersionBuild = int.parse(version.substring(clientVersion.length + 1)) + 1;
+              _clientVersionBuild = (forceVersion != null) ? forceVersion : int.parse(version.substring(clientVersion.length + 1)) + 1;
             }
           } else {
             print("Generator version changed.");
             print("Regenerating library $_libraryName");
-            _clientVersionBuild = 0;
+            _clientVersionBuild = (forceVersion != null) ? forceVersion : 0;
           }
         }
       } else {
         print("Library $_libraryName does not exist yet.");
         print("Generating library $_libraryName");
-        _clientVersionBuild = 0;
+        _clientVersionBuild = (forceVersion != null) ? forceVersion : 0;
       }
     }
 


### PR DESCRIPTION
I added a flag --version that in combination with --force allows us to reset the version of all the client libraries on GitHub.
so update.dart --force --version=0 will set all client libraries to version 0.1.0

I also added an (untested) block that will update the uploaders of the pub package. I think this is necessary so both of us can update the package on pub.

@financeCoding can you test if I broke the pub upload somehow that way, thanks.
