### PR TITLE
Handling the case when the JSON response is null during an error

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -996,7 +996,7 @@ abstract class BrowserClient extends Client {
     js.scoped(() {
       var request = js.context.gapi.client.request(js.map(requestData));
       var callback = new js.Callback.once((jsonResp, rawResp) {
-        if (jsonResp is core.bool && jsonResp == false) {
+        if (jsonResp == null || (jsonResp is core.bool && jsonResp == false)) {
           var raw = JSON.parse(rawResp);
           if (raw["gapiRequest"]["data"]["status"] >= 400) {
             completer.completeError(new APIRequestException("JS Client - \${raw["gapiRequest"]["data"]["status"]} \${raw["gapiRequest"]["data"]["statusText"]} - \${raw["gapiRequest"]["data"]["body"]}"));


### PR DESCRIPTION
`jsonResp` seems to be null during 503 errors (and probably others, but that's what I'm hitting currently), and if it's not handled here then everything breaks later on.
