### PR TITLE
Bug executing generated code from CloudEndpoint, related to issue #38

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -590,12 +590,17 @@ part "$srcFolder/console/$_name.dart";
           } else {
             if (object) {
               tmp.write("      $propName = new $type.fromJson(json[\"$jsonName\"]);\n");
-            } else {
-+              if(schemaType=="string" && schemaFormat == "int64") {
-+                tmp.write("      $propName = core.int.parse(json[\"$jsonName\"]);\n");                
-+              }else{            
-+                tmp.write("      $propName = json[\"$jsonName\"];\n");
-+              }             }
+            } else {              
+              if(schemaType=="string" && schemaFormat == "int64") {
+                tmp.write("      if(json[\"$jsonName\"] is core.String){\n");
+                tmp.write("        $propName = core.int.parse(json[\"$jsonName\"]);\n");
+                tmp.write("      }else{\n");
+                tmp.write("        $propName = json[\"$jsonName\"];\n");
+                tmp.write("      }\n");
+              }else{            
+                tmp.write("      $propName = json[\"$jsonName\"];\n");
+              }   
+            }
           }
           tmp.write("    }\n");
         }


### PR DESCRIPTION
When executing the code generated from a CloudEndpoint, with a resource with a property of type Long(Java), which appears in the discovery document as type:string and format:int64, throws an exception because tries to cast a string from the json to a int.

Related to the issue #38.
