### PR TITLE
Removing NSM access for array when access js.context

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -1027,7 +1027,7 @@ abstract class BrowserClient extends Client {
     }
 
     js.scoped((){
-      js.context.handleClientLoad =  new js.Callback.once(() {
+      js.context["handleClientLoad"] =  new js.Callback.once(() {
         _jsClientLoaded = true;
         completer.complete(true);
       });
@@ -1064,7 +1064,7 @@ abstract class BrowserClient extends Client {
     }
 
     js.scoped(() {
-      var request = js.context.gapi.client.request(js.map(requestData));
+      var request = js.context["gapi"]["client"]["request"](js.map(requestData));
       var callback = new js.Callback.once((jsonResp, rawResp) {
         if (jsonResp == null || (jsonResp is core.bool && jsonResp == false)) {
           var raw = JSON.parse(rawResp);
@@ -1074,7 +1074,7 @@ abstract class BrowserClient extends Client {
             completer.complete({});
           }
         } else {
-          completer.complete(js.context.JSON.stringify(jsonResp));
+          completer.complete(js.context["JSON"]["stringify"](jsonResp));
         }
       });
       request.execute(callback);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: discovery_api_client_generator
-version: 0.2.6
+version: 0.2.7
 authors:
 - Gerwin Sturm <scarygami@gmail.com>
 - Adam Singer <financeCoding@gmail.com>
 - Kevin Moore <kevin@thinkpixellab.com>
-description: Create API Client libraries based on the API's Discovery documentation
+description: Create API Client libraries based on the APIs Discovery documentation
 homepage: https://github.com/dart-gde/discovery_api_dart_client_generator
 environment:
   sdk: '>=0.5.13'


### PR DESCRIPTION
Important changes to remove NSM usage in js-interop so `--minify` flag will work on `dart2js`. Would like to publish new libraries tomorrow if possible. 
