### PR TITLE
Use secure connection for client.js

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -501,7 +501,7 @@ abstract class BrowserClient implements ClientBase {
     });
 
     html.ScriptElement script = new html.ScriptElement();
-    script.src = "http://apis.google.com/js/client.js?onload=handleClientLoad";
+    script.src = "https://apis.google.com/js/client.js?onload=handleClientLoad";
     script.type = "text/javascript";
     html.document.body.children.add(script);
 


### PR DESCRIPTION
Requesting client.js with http creates secure content warnings in browsers when you are on an secured website. Google anyways redirects you to the https version.
