### PR TITLE
flagging v0.2.0 of generator

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -3,7 +3,7 @@ part of discovery_api_client_generator;
 class Config {
   String get clientVersion => "0.2";
 
-  bool get isDev => true;
+  bool get isDev => false;
 
   String get dartEnvironmentVersionConstraint => '>=0.6.9';
 
@@ -19,7 +19,7 @@ class Config {
   };
 
   Map<String, String> get devDependencyVersions => const {
-    'hop': " '>=0.24.0'"
+    'hop': " '>=0.24.1'"
   };
 
   const Config();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discovery_api_client_generator
-version: 0.3.0-dev
+version: 0.2.0
 authors:
 - Gerwin Sturm <scarygami@gmail.com>
 - Adam Singer <financeCoding@gmail.com>


### PR DESCRIPTION
and updated released API versions to 0.2.0

Question: should we align the version of the released APIs w/ the generator? Bump them to 0.3.0?
