### PR TITLE
Fixes dart-gde/discovery_api_dart_client_generator#91

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=0.7.6'
 dependencies:
   args: '>=0.7.6'
-  google_discovery_v1_api: 0.3.8
+  google_discovery_v1_api: '>=0.4.9'
   logging: '>=0.7.6'
   meta: '>=0.7.6'
   path: '>=0.7.6'


### PR DESCRIPTION
This should fix the issue with the outdated dependency.
