### PR TITLE
Using dart:js instead of package:js

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -489,7 +489,7 @@ class DetailedApiRequestError extends Error {
 import "dart:async";
 import "dart:html" as html;
 import "dart:convert";
-import "package:js/js.dart" as js;
+import "dart:js" as js;
 import "package:google_oauth2_client/google_oauth2_browser.dart" as oauth;
 
 import 'client_base.dart';


### PR DESCRIPTION
Fixes #93 — tested using dart-sdk r28990

Using package:js: (dart2js -- minify)

2.4M    out/web/index.html_bootstrap.dart.js
3.0M    out/web/index.html_bootstrap.dart.precompiled.js

Using dart:js: (dart2js --minify)

344K    out/web/index.html_bootstrap.dart.js
524K    out/web/index.html_bootstrap.dart.precompiled.js

Can't test in r29341 because of other issues.
