### PR TITLE
Ensure uploads specify uploadType query param

### DIFF
--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -473,6 +473,8 @@ abstract class ClientBase {
     ..write(content)
     ..write(_closeDelim);
 
+    queryParams["uploadType"] = "multipart";
+
     return request(requestUrl, method, body: multiPartBody.toString(), contentType: "multipart/mixed; boundary=\"$_boundary\"", urlParams: urlParams, queryParams: queryParams);
   }
 


### PR DESCRIPTION
Previously, this was not specified resulting in inconsistent behaviour and zero size file uploads.

Resolves #113
