### PR TITLE
add a 'generated' file header

### DIFF
--- a/example/generated_client/lib/dartservices/v1.dart
+++ b/example/generated_client/lib/dartservices/v1.dart
@@ -1,3 +1,5 @@
+// This is a generated file (see the discoveryapis_generator project).
+
 library generated_client.dartservices.v1;
 
 import 'dart:core' as core;
@@ -526,5 +528,3 @@ class SourceRequest {
     return _json;
   }
 }
-
-

--- a/lib/src/dart_api_library.dart
+++ b/lib/src/dart_api_library.dart
@@ -73,7 +73,7 @@ class DartApiLibrary {
     } else {
       sink.write('$schemas');
     }
-    return '$sink';
+    return '${sink.toString().trimRight()}\n';
   }
 
   String libraryHeader() {
@@ -86,6 +86,8 @@ class DartApiLibrary {
     }
     return
 """
+// This is a generated file (see the discoveryapis_generator project).
+
 library $libraryName;
 
 import 'dart:core' as ${imports.core};


### PR DESCRIPTION
- add a file header saying that the file is a generated file (fix #133). It's useful for developers to be aware of auto-gened files, in case they're tempted to edit them.
- make sure that the gen'd file ends with a single newline

@mkustermann 