### PR TITLE
fix the merge for the ws PR

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -75,7 +75,7 @@ void dieWithUsage([String message]) {
   print("  package");
   print("  files");
   print("");
-  print("The 'package' subcommand generated an API package from already"
+  print("The 'package' subcommand generates an API package from already "
         "downloaded discovery documents. It takes the following options:");
   print("");
   print(packageCommandArgParser().usage);

--- a/test/src/client_generator_test.dart
+++ b/test/src/client_generator_test.dart
@@ -46,7 +46,9 @@ main() {
       var stubFile = new File(path.join(outputDir.path, 'toyapi.dart'));
       var expectedStubFile =
           new File(path.join(dataPath, 'expected_nonidentical.dartt'));
-      expect(stubFile.readAsStringSync(), expectedStubFile.readAsStringSync());
+      expect(
+          _normalizeWhiteSpace(stubFile.readAsStringSync()),
+          _normalizeWhiteSpace(expectedStubFile.readAsStringSync()));
     });
     test('identical-messages', () {
       var outputDir = tmpDir.createTempSync();
@@ -82,7 +84,15 @@ main() {
       var stubFile = new File(path.join(outputDir.path, 'toyapi.dart'));
       var expectedStubFile =
           new File(path.join(dataPath, 'expected_identical.dartt'));
-      expect(stubFile.readAsStringSync(), expectedStubFile.readAsStringSync());
+      expect(
+          _normalizeWhiteSpace(stubFile.readAsStringSync()),
+          _normalizeWhiteSpace(expectedStubFile.readAsStringSync()));
     });
   });
+}
+
+final RegExp _wsRegexp = new RegExp(r'\s+');
+
+String _normalizeWhiteSpace(String str) {
+  return str.replaceAll(_wsRegexp, '');
 }

--- a/tool/hop_runner.dart
+++ b/tool/hop_runner.dart
@@ -17,7 +17,7 @@ void main(List<String> args) {
   addTask('generate_example', commandlineTasks([
     commandRunner('dart', [
       'bin/generate.dart',
-      'generate',
+      'package',
       '--input-dir=example',
       '--output-dir=example/generated_client',
       '--package-name=generated_client'])

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -9,3 +9,6 @@ set -e
 
 # Run Hop.
 dart --checked tool/hop_runner.dart test
+
+# Validate that we can re-generate the example discovery doc.
+dart --checked tool/hop_runner.dart generate_example


### PR DESCRIPTION
Fix the merge for https://github.com/dart-lang/discoveryapis_generator/pull/142.

- change the `client_generator_test.dart` to ignore whitespace in generated files
- update the hop command that generates example output
- validate that we can re-run example output after each commit

@wibling @mkustermann 

Also, I think we'll want to adjust some aspects of the `client_generator_test.dart` tests. It's not clear to me how to re-gen these files when the generator changes. And, if we're just committing new generated versions of these files with each PR, and then testing that the generator generates the same content, I'm not sure what we're testing.
