### PR TITLE
widen pubspec constraints; add an executable section

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,13 +3,19 @@ version: 0.7.0
 author: Dart Team <misc@dartlang.org>
 description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator
+
 environment:
   sdk: '>=1.0.0 <2.0.0'
+
 dependencies:
-  args: '>=0.12.1 <0.13.0'
+  args: '>=0.12.1 <0.14.0'
   http: '>=0.11.1 <0.12.0'
   path: '>=1.3.3 <2.0.0'
   yaml: '>=2.0.0 <3.0.0'
+
 dev_dependencies:
-  hop: '>=0.30.2 <0.32.0'
+  hop: '>=0.30.2 <0.33.0'
   unittest: '>=0.10.0 <0.12.0'
+
+executables:
+  discoveryapis_generator: generate


### PR DESCRIPTION
- widen the constraints on packages w/ updates
- add an executable to the pubspec (fix #135)

