### PR TITLE
address warnings in the generated core; remove the core. prefix

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -48,7 +48,7 @@ ArgParser filesCommandArgParser() {
                         'dependencies. This will remove comments and might '
                         'change the layout of the pubspec.yaml file.',
                   defaultsTo: 'false')
-      ..addFlag('core-prefix',
+      ..addFlag('core-prefixes',
                 negatable: true,
                 defaultsTo: true,
                 help: 'Use or remove an import prefix for dart:core');
@@ -122,10 +122,11 @@ void main(List<String> arguments) {
           .toLowerCase()
           .replaceAll('=', '')
           .trim();
-      printResults(generateApiFiles(commandOptions['input-dir'],
-                                    commandOptions['output-dir'],
-                                    updatePubspec: updatePubspec == 'true',
-                                    useCorePrefix: commandOptions['core-prefix']));
+      printResults(
+          generateApiFiles(commandOptions['input-dir'],
+                           commandOptions['output-dir'],
+                           updatePubspec: updatePubspec == 'true',
+                           useCorePrefixes: commandOptions['core-prefixes']));
       break;
   }
 }

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -47,7 +47,11 @@ ArgParser filesCommandArgParser() {
                   help: 'Update the pubspec.yaml file with required '
                         'dependencies. This will remove comments and might '
                         'change the layout of the pubspec.yaml file.',
-                  defaultsTo: 'false');
+                  defaultsTo: 'false')
+      ..addFlag('core-prefix',
+                negatable: true,
+                defaultsTo: true,
+                help: 'Use or remove an import prefix for dart:core');
 }
 
 ArgParser globalArgParser() {
@@ -120,7 +124,8 @@ void main(List<String> arguments) {
           .trim();
       printResults(generateApiFiles(commandOptions['input-dir'],
                                     commandOptions['output-dir'],
-                                    updatePubspec: updatePubspec == 'true'));
+                                    updatePubspec: updatePubspec == 'true',
+                                    useCorePrefix: commandOptions['core-prefix']));
       break;
   }
 }

--- a/example/dartservices.dart
+++ b/example/dartservices.dart
@@ -2,25 +2,22 @@
 
 library discoveryapis_generator.dartservices.v1;
 
-import 'dart:core' as core;
-import 'dart:collection' as collection;
-import 'dart:async' as async;
+import 'dart:async';
 import 'dart:convert' as convert;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
-import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 
 export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show
     ApiRequestError, DetailedApiRequestError;
 
-const core.String USER_AGENT = 'dart-api-client dartservices/v1';
+const String USER_AGENT = 'dart-api-client dartservices/v1';
 
 class DartservicesApi {
 
   final commons.ApiRequester _requester;
 
-  DartservicesApi(http.Client client, {core.String rootUrl: "http://localhost/", core.String servicePath: "api/dartservices/v1/"}) :
+  DartservicesApi(http.Client client, {String rootUrl: "http://localhost/", String servicePath: "api/dartservices/v1/"}) :
       _requester = new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
 
   /**
@@ -36,9 +33,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<AnalysisResults> analyze(SourceRequest request) {
+  Future<AnalysisResults> analyze(SourceRequest request) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -73,9 +70,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<AnalysisResults> analyzeGet({core.String source}) {
+  Future<AnalysisResults> analyzeGet({String source}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -110,9 +107,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<CompileResponse> compile(SourceRequest request) {
+  Future<CompileResponse> compile(SourceRequest request) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -147,9 +144,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<CompileResponse> compileGet({core.String source}) {
+  Future<CompileResponse> compileGet({String source}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -182,9 +179,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future complete(SourceRequest request) {
+  Future complete(SourceRequest request) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -221,9 +218,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future completeGet({core.String source, core.int offset}) {
+  Future completeGet({String source, int offset}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -263,9 +260,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<DocumentResponse> document(SourceRequest request) {
+  Future<DocumentResponse> document(SourceRequest request) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -302,9 +299,9 @@ class DartservicesApi {
    * If the used [http.Client] completes with an error when making a REST call,
    * this method will complete with the same error.
    */
-  async.Future<DocumentResponse> documentGet({core.String source, core.int offset}) {
+  Future<DocumentResponse> documentGet({String source, int offset}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -334,16 +331,16 @@ class DartservicesApi {
 
 
 class AnalysisIssue {
-  core.int charLength;
-  core.int charStart;
-  core.String kind;
-  core.int line;
-  core.String location;
-  core.String message;
+  int charLength;
+  int charStart;
+  String kind;
+  int line;
+  String location;
+  String message;
 
   AnalysisIssue();
 
-  AnalysisIssue.fromJson(core.Map _json) {
+  AnalysisIssue.fromJson(Map _json) {
     if (_json.containsKey("charLength")) {
       charLength = _json["charLength"];
     }
@@ -364,8 +361,8 @@ class AnalysisIssue {
     }
   }
 
-  core.Map toJson() {
-    var _json = new core.Map();
+  Map toJson() {
+    var _json = new Map();
     if (charLength != null) {
       _json["charLength"] = charLength;
     }
@@ -389,18 +386,18 @@ class AnalysisIssue {
 }
 
 class AnalysisResults {
-  core.List<AnalysisIssue> issues;
+  List<AnalysisIssue> issues;
 
   AnalysisResults();
 
-  AnalysisResults.fromJson(core.Map _json) {
+  AnalysisResults.fromJson(Map _json) {
     if (_json.containsKey("issues")) {
       issues = _json["issues"].map((value) => new AnalysisIssue.fromJson(value)).toList();
     }
   }
 
-  core.Map toJson() {
-    var _json = new core.Map();
+  Map toJson() {
+    var _json = new Map();
     if (issues != null) {
       _json["issues"] = issues.map((value) => (value).toJson()).toList();
     }
@@ -409,18 +406,18 @@ class AnalysisResults {
 }
 
 class CompileResponse {
-  core.String result;
+  String result;
 
   CompileResponse();
 
-  CompileResponse.fromJson(core.Map _json) {
+  CompileResponse.fromJson(Map _json) {
     if (_json.containsKey("result")) {
       result = _json["result"];
     }
   }
 
-  core.Map toJson() {
-    var _json = new core.Map();
+  Map toJson() {
+    var _json = new Map();
     if (result != null) {
       _json["result"] = result;
     }
@@ -429,18 +426,18 @@ class CompileResponse {
 }
 
 class DocumentResponse {
-  core.Map<core.String, core.String> info;
+  Map<String, String> info;
 
   DocumentResponse();
 
-  DocumentResponse.fromJson(core.Map _json) {
+  DocumentResponse.fromJson(Map _json) {
     if (_json.containsKey("info")) {
       info = _json["info"];
     }
   }
 
-  core.Map toJson() {
-    var _json = new core.Map();
+  Map toJson() {
+    var _json = new Map();
     if (info != null) {
       _json["info"] = info;
     }
@@ -449,12 +446,12 @@ class DocumentResponse {
 }
 
 class SourceRequest {
-  core.int offset;
-  core.String source;
+  int offset;
+  String source;
 
   SourceRequest();
 
-  SourceRequest.fromJson(core.Map _json) {
+  SourceRequest.fromJson(Map _json) {
     if (_json.containsKey("offset")) {
       offset = _json["offset"];
     }
@@ -463,8 +460,8 @@ class SourceRequest {
     }
   }
 
-  core.Map toJson() {
-    var _json = new core.Map();
+  Map toJson() {
+    var _json = new Map();
     if (offset != null) {
       _json["offset"] = offset;
     }

--- a/lib/discoveryapis_generator.dart
+++ b/lib/discoveryapis_generator.dart
@@ -67,7 +67,7 @@ List<GenerateResult> generateAllLibraries(String inputDirectory,
 List<GenerateResult> generateApiFiles(String inputDirectory,
                                       String outputDirectory,
                                       {bool updatePubspec: false,
-                                       bool useCorePrefix: true}) {
+                                       bool useCorePrefixes: true}) {
   var descriptions = [];
   new Directory(inputDirectory).listSync()
       .where((fse) => fse is File && fse.path.endsWith('.json'))
@@ -77,6 +77,6 @@ List<GenerateResult> generateApiFiles(String inputDirectory,
   });
   var clientFileGenerator = new ApisFilesGenerator(
       descriptions, outputDirectory, updatePubspec: updatePubspec,
-      useCorePrefix: useCorePrefix);
+      useCorePrefixes: useCorePrefixes);
   return clientFileGenerator.generate();
 }

--- a/lib/discoveryapis_generator.dart
+++ b/lib/discoveryapis_generator.dart
@@ -66,7 +66,8 @@ List<GenerateResult> generateAllLibraries(String inputDirectory,
 
 List<GenerateResult> generateApiFiles(String inputDirectory,
                                       String outputDirectory,
-                                      {bool updatePubspec: false}) {
+                                      {bool updatePubspec: false,
+                                       bool useCorePrefix: true}) {
   var descriptions = [];
   new Directory(inputDirectory).listSync()
       .where((fse) => fse is File && fse.path.endsWith('.json'))
@@ -75,6 +76,7 @@ List<GenerateResult> generateApiFiles(String inputDirectory,
     descriptions.add(diPair);
   });
   var clientFileGenerator = new ApisFilesGenerator(
-      descriptions, outputDirectory, updatePubspec: updatePubspec);
+      descriptions, outputDirectory, updatePubspec: updatePubspec,
+      useCorePrefix: useCorePrefix);
   return clientFileGenerator.generate();
 }

--- a/lib/src/apis_files_generator.dart
+++ b/lib/src/apis_files_generator.dart
@@ -27,6 +27,7 @@ class ApisFilesGenerator {
   final List<DescriptionImportPair> descriptions;
   final String clientFolderPath;
   final bool updatePubspec;
+  final bool useCorePrefix;
   String packageRoot;
   File pubspecFile;
 
@@ -34,7 +35,7 @@ class ApisFilesGenerator {
   /// [clientFolderPath] is the output directory for the generated client stub
   /// code.
   ApisFilesGenerator(this.descriptions, this.clientFolderPath,
-                     {this.updatePubspec: false}) {
+                     {this.updatePubspec: false, this.useCorePrefix: true}) {
     // Create the output directory.
     var clientDirectory = new Directory(clientFolderPath);
     packageRoot = findPackageRoot(path.absolute(clientDirectory.path));
@@ -71,7 +72,8 @@ class ApisFilesGenerator {
         if (diPair.importMap == null) {
           // Build a normal client stub file without using the same message
           // classes.
-          lib = new DartApiLibrary.build(description, packageName);
+          lib = new DartApiLibrary.build(description, packageName,
+              useCorePrefix: useCorePrefix);
         } else {
           // Build a client stub api using common message classes.
           lib = new ClientApiLibrary.build(

--- a/lib/src/apis_files_generator.dart
+++ b/lib/src/apis_files_generator.dart
@@ -27,7 +27,7 @@ class ApisFilesGenerator {
   final List<DescriptionImportPair> descriptions;
   final String clientFolderPath;
   final bool updatePubspec;
-  final bool useCorePrefix;
+  final bool useCorePrefixes;
   String packageRoot;
   File pubspecFile;
 
@@ -35,7 +35,7 @@ class ApisFilesGenerator {
   /// [clientFolderPath] is the output directory for the generated client stub
   /// code.
   ApisFilesGenerator(this.descriptions, this.clientFolderPath,
-                     {this.updatePubspec: false, this.useCorePrefix: true}) {
+                     {this.updatePubspec: false, this.useCorePrefixes: true}) {
     // Create the output directory.
     var clientDirectory = new Directory(clientFolderPath);
     packageRoot = findPackageRoot(path.absolute(clientDirectory.path));
@@ -73,7 +73,7 @@ class ApisFilesGenerator {
           // Build a normal client stub file without using the same message
           // classes.
           lib = new DartApiLibrary.build(description, packageName,
-              useCorePrefix: useCorePrefix);
+              useCorePrefixes: useCorePrefixes);
         } else {
           // Build a client stub api using common message classes.
           lib = new ClientApiLibrary.build(

--- a/lib/src/client/client_api_library.dart
+++ b/lib/src/client/client_api_library.dart
@@ -87,6 +87,11 @@ class ClientApiLibrary extends BaseApiLibrary {
     return '$sink';
   }
 
+  /**
+   * Create the library header. Note, this must be called after the library
+   * source string has been generated, since it relies on [Identifier] usage
+   * counts being calculated
+   */
   String libraryHeader() {
     var exportedMediaClasses = '';
     if (exposeMedia) {

--- a/lib/src/client/client_api_library.dart
+++ b/lib/src/client/client_api_library.dart
@@ -35,8 +35,8 @@ class ClientApiLibrary extends BaseApiLibrary {
                          Map<String, String> importMap,
                          this.packageName,
                          this.packageRoot,
-                         {bool useCorePrefix: true})
-      : super(description, '', useCorePrefix: useCorePrefix) {
+                         {bool useCorePrefixes: true})
+      : super(description, '', useCorePrefixes: useCorePrefixes) {
     libraryName = namer.clientLibraryName(packageName, description.name);
     schemaDB = client.parseSchemas(imports, description);
     apiClass = parseResources(imports, schemaDB, description);

--- a/lib/src/client/client_api_library.dart
+++ b/lib/src/client/client_api_library.dart
@@ -34,8 +34,9 @@ class ClientApiLibrary extends BaseApiLibrary {
   ClientApiLibrary.build(RestDescription description,
                          Map<String, String> importMap,
                          this.packageName,
-                         this.packageRoot)
-      : super(description, '') {
+                         this.packageRoot,
+                         {bool useCorePrefix: true})
+      : super(description, '', useCorePrefix: useCorePrefix) {
     libraryName = namer.clientLibraryName(packageName, description.name);
     schemaDB = client.parseSchemas(imports, description);
     apiClass = parseResources(imports, schemaDB, description);
@@ -94,23 +95,45 @@ class ClientApiLibrary extends BaseApiLibrary {
           'PartialDownloadOptions,\n'
           '    ByteRange';
     }
-    return
-"""
+
+    String result = """
+// This is a generated file (see the discoveryapis_generator project).
+
 library $libraryName;
 
-import 'dart:core' as ${imports.core};
-import 'dart:collection' as ${imports.collection};
-import 'dart:async' as ${imports.async};
+""";
+
+    if (imports.core.hasPrefix) {
+      result += "import 'dart:core' as ${imports.core};\n";
+    }
+
+    if (imports.collection.wasCalled) {
+      result += "import 'dart:collection' as ${imports.collection};\n";
+    }
+
+    if (imports.async.hasPrefix) {
+      result += "import 'dart:async' as ${imports.async};\n";
+    } else {
+      result += "import 'dart:async';\n";
+    }
+
+    result += """
 import 'dart:convert' as ${imports.convert};
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as ${imports.commons};
-import 'package:crypto/crypto.dart' as ${imports.crypto};
+""";
+
+    if (imports.crypto.wasCalled) {
+      result += "import 'package:crypto/crypto.dart' as ${imports.crypto};\n";
+    }
+
+    return result + """
 import 'package:http/http.dart' as ${imports.http};
 $schemaImports
 export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show
     ApiRequestError, DetailedApiRequestError${exportedMediaClasses};
 
-const ${imports.core}.String USER_AGENT = 'dart-api-client ${description.name}/${description.version}';
+const ${imports.core.ref()}String USER_AGENT = 'dart-api-client ${description.name}/${description.version}';
 
 """;
   }

--- a/lib/src/dart_api_library.dart
+++ b/lib/src/dart_api_library.dart
@@ -83,6 +83,11 @@ class DartApiLibrary extends BaseApiLibrary {
     return '${sink.toString().trimRight()}\n';
   }
 
+  /**
+   * Create the library header. Note, this must be called after the library
+   * source string has been generated, since it relies on [Identifier] usage
+   * counts being calculated
+   */
   String libraryHeader() {
     var exportedMediaClasses = '';
     if (exposeMedia) {

--- a/lib/src/dart_api_library.dart
+++ b/lib/src/dart_api_library.dart
@@ -23,11 +23,11 @@ class DartApiImports {
   Identifier http;
   Identifier commons;
 
-  DartApiImports.fromNamer(this.namer, {bool useCorePrefix: true}) {
-    core = useCorePrefix ? namer.import('core') : namer.noPrefix();
+  DartApiImports.fromNamer(this.namer, {bool useCorePrefixes: true}) {
+    core = useCorePrefixes ? namer.import('core') : namer.noPrefix();
     collection = namer.import('collection');
     crypto = namer.import('crypto');
-    async = useCorePrefix ? namer.import('async') : namer.noPrefix();
+    async = useCorePrefixes ? namer.import('async') : namer.noPrefix();
     convert = namer.import('convert');
     http = namer.import('http');
     commons = namer.import('commons');
@@ -41,9 +41,10 @@ abstract class BaseApiLibrary {
   DartApiImports imports;
 
   BaseApiLibrary(this.description, String apiClassSuffix,
-      {bool useCorePrefix: true}) :
+      {bool useCorePrefixes: true}) :
       namer = new ApiLibraryNamer(apiClassSuffix: apiClassSuffix) {
-    imports = new DartApiImports.fromNamer(namer, useCorePrefix: useCorePrefix);
+    imports = new DartApiImports.fromNamer(namer,
+        useCorePrefixes: useCorePrefixes);
   }
 }
 
@@ -60,8 +61,8 @@ class DartApiLibrary extends BaseApiLibrary {
    * Generates a API library for [description].
    */
   DartApiLibrary.build(RestDescription description, String packageName,
-      {bool useCorePrefix: true}) :
-      super(description, 'Api', useCorePrefix: useCorePrefix) {
+      {bool useCorePrefixes: true}) :
+      super(description, 'Api', useCorePrefixes: useCorePrefixes) {
     libraryName = namer.libraryName(
         packageName, description.name, description.version);
     schemaDB = parseSchemas(imports, description);

--- a/lib/src/dart_resources.dart
+++ b/lib/src/dart_resources.dart
@@ -144,7 +144,7 @@ class DartResourceMethod {
     if (returnType != null && !mediaDownload) {
       genericReturnType = '<${returnType.declaration}>';
     }
-    return '${imports.async}.Future$genericReturnType $name($parameterString)';
+    return '${imports.async.ref()}Future$genericReturnType $name($parameterString)';
   }
 
   String get definition {
@@ -227,7 +227,7 @@ class DartResourceMethod {
         } else {
           params.writeln('    if (${param.name} == null) {');
         }
-        params.writeln('      throw new ${imports.core}.ArgumentError'
+        params.writeln('      throw new ${imports.core.ref()}ArgumentError'
                        '("Parameter ${param.name} is required.");');
         params.writeln('    }');
       } else {
@@ -265,7 +265,7 @@ class DartResourceMethod {
         } else {
           params.writeln('    if (${param.name} == null) {');
         }
-        params.writeln('      throw new ${imports.core}.ArgumentError'
+        params.writeln('      throw new ${imports.core.ref()}ArgumentError'
                        '("Parameter ${param.name} is required.");');
         params.writeln('    }');
         params.writeln('    $propertyAssignment');
@@ -364,7 +364,7 @@ $urlPatternCode
 
     methodString.write('''
     var _url = null;
-    var _queryParams = new ${imports.core}.Map();
+    var _queryParams = new ${imports.core.ref()}Map();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = ${imports.commons}.DownloadOptions.Metadata;
@@ -471,8 +471,8 @@ class DartApiClass extends DartResourceClass {
     var str = new StringBuffer();
 
     var parameters = [
-        '${imports.core}.String rootUrl: "${escapeString(rootUrl)}"',
-        '${imports.core}.String servicePath: "${escapeString(servicePath)}"',
+        '${imports.core.ref()}String rootUrl: "${escapeString(rootUrl)}"',
+        '${imports.core.ref()}String servicePath: "${escapeString(servicePath)}"',
     ].join(', ');
 
     str.writeln('  $className(${imports.http}.Client client, {$parameters}) :');

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -212,21 +212,21 @@ abstract class PrimitiveDartSchemaType extends DartSchemaType {
 class BooleanType extends PrimitiveDartSchemaType {
   BooleanType(DartApiImports imports) : super(imports);
 
-  String get declaration => '${imports.core}.bool';
+  String get declaration => '${imports.core.ref()}bool';
 }
 
 
 class IntegerType extends PrimitiveDartSchemaType {
   IntegerType(DartApiImports imports) : super(imports);
 
-  String get declaration => '${imports.core}.int';
+  String get declaration => '${imports.core.ref()}int';
 }
 
 
 class DoubleType extends PrimitiveDartSchemaType {
   DoubleType(DartApiImports imports) : super(imports);
 
-  String get declaration => '${imports.core}.double';
+  String get declaration => '${imports.core.ref()}double';
 }
 
 
@@ -234,7 +234,7 @@ class StringType extends PrimitiveDartSchemaType {
   StringType(DartApiImports imports) : super(imports);
 
   String primitiveEncoding(String value) => value;
-  String get declaration => '${imports.core}.String';
+  String get declaration => '${imports.core.ref()}String';
 }
 
 
@@ -264,7 +264,7 @@ class EnumType extends StringType {
 class DateType extends StringType {
   DateType(DartApiImports imports) : super(imports);
 
-  String get declaration => '${imports.core}.DateTime';
+  String get declaration => '${imports.core.ref()}DateTime';
 
   String primitiveEncoding(String value)
       => '"\${($value).year.toString().padLeft(4, \'0\')}-'
@@ -273,20 +273,20 @@ class DateType extends StringType {
 
   String jsonEncode(String value) => primitiveEncoding(value);
 
-  String jsonDecode(String json) => '${imports.core}.DateTime.parse($json)';
+  String jsonDecode(String json) => '${imports.core.ref()}DateTime.parse($json)';
 }
 
 
 class DateTimeType extends StringType {
   DateTimeType(DartApiImports imports) : super(imports);
 
-  String get declaration => '${imports.core}.DateTime';
+  String get declaration => '${imports.core.ref()}DateTime';
 
   String primitiveEncoding(String value) => '($value).toIso8601String()';
 
   String jsonEncode(String value) => '($value).toIso8601String()';
 
-  String jsonDecode(String json) => '${imports.core}.DateTime.parse($json)';
+  String jsonDecode(String json) => '${imports.core.ref()}DateTime.parse($json)';
 }
 
 
@@ -299,7 +299,7 @@ class DateTimeType extends StringType {
 class AnyType extends PrimitiveDartSchemaType {
   AnyType(DartApiImports imports) : super(imports);
 
-  String get declaration => '${imports.core}.Object';
+  String get declaration => '${imports.core.ref()}Object';
 }
 
 
@@ -342,7 +342,7 @@ class UnnamedArrayType extends ComplexDartSchemaType {
 
   String get classDefinition => null;
 
-  String get declaration => '${imports.core}.List<${innerType.declaration}>';
+  String get declaration => '${imports.core.ref()}List<${innerType.declaration}>';
 
   String jsonEncode(String value) {
     if (innerType.needsJsonEncoding) {
@@ -385,12 +385,12 @@ class NamedArrayType extends ComplexDartSchemaType {
 
   String get classDefinition {
     var decode = new StringBuffer();
-    decode.writeln('  $className.fromJson(${imports.core}.List json)');
+    decode.writeln('  $className.fromJson(${imports.core.ref()}List json)');
     decode.writeln('      : _inner = json.map((value) => '
                    '${innerType.jsonDecode('value')}).toList();');
 
     var encode = new StringBuffer();
-    encode.writeln('  ${imports.core}.List toJson() {');
+    encode.writeln('  ${imports.core.ref()}List toJson() {');
     encode.writeln('    return _inner.map((value) => '
                    '${innerType.jsonEncode('value')}).toList();');
     encode.write('  }');
@@ -399,23 +399,23 @@ class NamedArrayType extends ComplexDartSchemaType {
     return
 '''
 ${comment.asDartDoc(0)}class $className
-    extends ${imports.collection}.ListBase<$type> {
-  final ${imports.core}.List<$type> _inner;
+    extends ${imports.collection.ref()}ListBase<$type> {
+  final ${imports.core.ref()}List<$type> _inner;
 
   $className() : _inner = [];
 
 $decode
 $encode
 
-  $type operator [](${imports.core}.int key) => _inner[key];
+  $type operator [](${imports.core.ref()}int key) => _inner[key];
 
-  void operator []=(${imports.core}.int key, $type value) {
+  void operator []=(${imports.core.ref()}int key, $type value) {
     _inner[key] = value;
   }
 
-  ${imports.core}.int get length => _inner.length;
+  ${imports.core.ref()}int get length => _inner.length;
 
-  void set length(${imports.core}.int newLength) {
+  void set length(${imports.core.ref()}int newLength) {
     _inner.length = newLength;
   }
 }
@@ -467,7 +467,7 @@ class UnnamedMapType extends ComplexDartSchemaType {
   String get declaration {
     var from = fromType.declaration;
     var to = toType.declaration;
-    return '${imports.core}.Map<$from, $to>';
+    return '${imports.core.ref()}Map<$from, $to>';
   }
 
   String jsonEncode(String value) {
@@ -520,16 +520,16 @@ class NamedMapType extends ComplexDartSchemaType {
 
   String get classDefinition {
     var decode = new StringBuffer();
-    decode.writeln('  $className.fromJson(${imports.core}.Map _json) {');
-    decode.writeln('    _json.forEach((${imports.core}.String key, value) {');
+    decode.writeln('  $className.fromJson(${imports.core.ref()}Map _json) {');
+    decode.writeln('    _json.forEach((${imports.core.ref()}String key, value) {');
     decode.writeln('      this[key] = ${toType.jsonDecode('value')};');
     decode.writeln('    });');
     decode.writeln('  }');
 
     var encode = new StringBuffer();
-    encode.writeln('  ${imports.core}.Map toJson() {');
+    encode.writeln('  ${imports.core.ref()}Map toJson() {');
     encode.writeln('    var _json = {};');
-    encode.writeln('    this.forEach((${imports.core}.String key, value) {');
+    encode.writeln('    this.forEach((${imports.core.ref()}String key, value) {');
     encode.writeln('      _json[key] = ${toType.jsonEncode('value')};');
     encode.writeln('    });');
     encode.writeln('    return _json;');
@@ -541,15 +541,15 @@ class NamedMapType extends ComplexDartSchemaType {
     return
 '''
 ${comment.asDartDoc(0)}class $className
-    extends ${imports.collection}.MapBase<$fromT, $toT> {
-  final ${imports.core}.Map _innerMap = {};
+    extends ${imports.collection.ref()}MapBase<$fromT, $toT> {
+  final ${imports.core.ref()}Map _innerMap = {};
 
   $className();
 
 $decode
 $encode
 
-  ${toType.declaration} operator [](${imports.core}.Object key)
+  ${toType.declaration} operator [](${imports.core.ref()}Object key)
       => _innerMap[key];
 
   operator []=($fromT key, $toT value) {
@@ -560,9 +560,9 @@ $encode
     _innerMap.clear();
   }
 
-  ${imports.core}.Iterable<$fromT> get keys => _innerMap.keys;
+  ${imports.core.ref()}Iterable<$fromT> get keys => _innerMap.keys;
 
-  $toT remove(${imports.core}.Object key) => _innerMap.remove(key);
+  $toT remove(${imports.core.ref()}Object key) => _innerMap.remove(key);
 }
 ''';
   }
@@ -630,10 +630,10 @@ class ObjectType extends ComplexDartSchemaType {
 
       if (property.byteArrayAccessor != null) {
         propertyString.writeln(
-            '  ${imports.core}.List<${imports.core}.int> get '
+            '  ${imports.core.ref()}List<${imports.core.ref()}int> get '
             '${property.byteArrayAccessor} {');
         propertyString.writeln('    return '
-            '${imports.crypto}.CryptoUtils.base64StringToBytes'
+            '${imports.crypto.ref()}CryptoUtils.base64StringToBytes'
             '(${property.name});');
         propertyString.writeln('  }');
 
@@ -642,8 +642,8 @@ class ObjectType extends ComplexDartSchemaType {
         propertyString.write(
             '  void set ${property.byteArrayAccessor}');
         propertyString.writeln(
-            '(${imports.core}.List<${imports.core}.int> _bytes) {');
-        propertyString.writeln('    ${property.name} = ${imports.crypto}.'
+            '(${imports.core.ref()}List<${imports.core.ref()}int> _bytes) {');
+        propertyString.writeln('    ${property.name} = ${imports.crypto.ref()}'
             'CryptoUtils.bytesToBase64(_bytes, urlSafe: true);');
         propertyString.writeln('  }');
       }
@@ -651,7 +651,7 @@ class ObjectType extends ComplexDartSchemaType {
 
     var fromJsonString = new StringBuffer();
     fromJsonString.writeln(
-        '  $className.fromJson(${imports.core}.Map _json) {');
+        '  $className.fromJson(${imports.core.ref()}Map _json) {');
     properties.forEach((DartClassProperty property) {
       // The super variant fromJson() will call this subclass constructor
       // and the variant descriminator is final.
@@ -667,8 +667,8 @@ class ObjectType extends ComplexDartSchemaType {
     fromJsonString.writeln('  }');
 
     var toJsonString = new StringBuffer();
-    toJsonString.writeln('  ${imports.core}.Map toJson() {');
-    toJsonString.writeln('    var _json = new ${imports.core}.Map();');
+    toJsonString.writeln('  ${imports.core.ref()}Map toJson() {');
+    toJsonString.writeln('    var _json = new ${imports.core.ref()}Map();');
 
     properties.forEach((DartClassProperty property) {
       toJsonString.writeln('    if (${property.name} != null) {');
@@ -757,7 +757,7 @@ class AbstractVariantType extends ComplexDartSchemaType {
   String get classDefinition {
     var fromJsonString = new StringBuffer();
     fromJsonString.writeln(
-        '  factory $className.fromJson(${imports.core}.Map json) {');
+        '  factory $className.fromJson(${imports.core.ref()}Map json) {');
     fromJsonString.writeln('    var discriminant = json["$discriminant"];');
     map.forEach((String name, DartSchemaType type) {
       fromJsonString.writeln('    if (discriminant == "$name") {');
@@ -765,12 +765,12 @@ class AbstractVariantType extends ComplexDartSchemaType {
                              '.fromJson(json);');
       fromJsonString.writeln('    }');
     });
-    fromJsonString.writeln('    throw new ${imports.core}.ArgumentError'
+    fromJsonString.writeln('    throw new ${imports.core.ref()}ArgumentError'
                            '("Invalid discriminant: \$discriminant!");');
     fromJsonString.writeln('  }');
 
     var toJsonString = new StringBuffer();
-    toJsonString.writeln('  ${imports.core}.Map toJson();');
+    toJsonString.writeln('  ${imports.core.ref()}Map toJson();');
 
     return
 '''

--- a/lib/src/namer.dart
+++ b/lib/src/namer.dart
@@ -12,17 +12,24 @@ import 'utils.dart';
 class Identifier {
   String _name;
   bool _sealed = false;
+  int _callCount = 0;
 
   /**
    * The prefered name for this [Identifier].
    */
   final String preferredName;
 
+  Identifier.noPrefix() : this.preferredName = null {
+    sealWithName(null);
+  }
+
   /**
    * Constructs a new [Identifier] with the given [preferredName]. The
    * identifier will be not sealed.
    */
   Identifier(this.preferredName);
+
+  bool get hasPrefix => preferredName != null;
 
   /**
    * The allocated name for this [Identifier]. This will be [:null:] until
@@ -40,6 +47,26 @@ class Identifier {
     }
     _name = name;
     _sealed = true;
+  }
+
+  /**
+   * Return the reference name with a `.` appended (e.g., `core.`). Calling this
+   * method will increment the call count; it is not idempotent.
+   */
+  String ref() {
+    _callCount++;
+    return name == null ? '' : '${name}.';
+  }
+
+  int get callCount => _callCount;
+
+  bool get wasCalled => callCount > 0;
+
+  /**
+   * Reset the [callCount].
+   */
+  void resetCallCount() {
+    _callCount = 0;
   }
 
   /**
@@ -200,7 +227,7 @@ class IdentifierNamer {
   IdentifierNamer.fromNameSet(this.allocatedNames) : parentNamer = null;
 
   /**
-   * Gives [Identifier] a unique name amongst al previously named identifiers
+   * Gives [Identifier] a unique name amongst all previously named identifiers
    * and amongst all identifiers of [parentNamer].
    */
   void nameIdentifier(Identifier identifier) {
@@ -259,6 +286,8 @@ class ApiLibraryNamer {
     api = Scope.toValidIdentifier(api, removeUnderscores: false);
     return '$package.$api.client';
   }
+
+  Identifier noPrefix() => new Identifier.noPrefix();
 
   Identifier import(String name)
       => importScope.newIdentifier(name, removeUnderscores: false);

--- a/lib/src/namer.dart
+++ b/lib/src/namer.dart
@@ -19,6 +19,9 @@ class Identifier {
    */
   final String preferredName;
 
+  /**
+   * [noPrefix] is used for naming prefix imports which will not get a name.
+   */
   Identifier.noPrefix() : this.preferredName = null {
     sealWithName(null);
   }
@@ -58,16 +61,7 @@ class Identifier {
     return name == null ? '' : '${name}.';
   }
 
-  int get callCount => _callCount;
-
-  bool get wasCalled => callCount > 0;
-
-  /**
-   * Reset the [callCount].
-   */
-  void resetCallCount() {
-    _callCount = 0;
-  }
+  bool get wasCalled => _callCount > 0;
 
   /**
    * Gets a string representation of this [Identifier]. This can only be called

--- a/test/src/client_generator_test.dart
+++ b/test/src/client_generator_test.dart
@@ -50,6 +50,7 @@ main() {
           _normalizeWhiteSpace(stubFile.readAsStringSync()),
           _normalizeWhiteSpace(expectedStubFile.readAsStringSync()));
     });
+
     test('identical-messages', () {
       var outputDir = tmpDir.createTempSync();
       // Make sure there is a pubspec.yaml file in the directory.

--- a/test/src/data/expected_identical.dartt
+++ b/test/src/data/expected_identical.dartt
@@ -1,3 +1,5 @@
+// This is a generated file (see the discoveryapis_generator project).
+
 library discoveryapis_tests.toyApi.client;
 
 import 'dart:core' as core;
@@ -29,7 +31,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future failing() {
     var _url = null;
@@ -63,7 +65,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> hello() {
     var _url = null;
@@ -72,7 +74,6 @@ class ToyApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'hello';
@@ -98,7 +99,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.Map<core.String, ToyResponse>> helloListOfClass(core.List<ToyRequest> request) {
     var _url = null;
@@ -111,7 +112,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request.map((value) => ToyRequestFactory.toJson(value)).toList());
     }
-
 
     _url = 'helloListOfClass';
 
@@ -136,7 +136,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.Map<core.String, ToyResponse>> helloListOfListOfClass(core.List<core.List<ToyRequest>> request) {
     var _url = null;
@@ -149,7 +149,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request.map((value) => value.map((value) => ToyRequestFactory.toJson(value)).toList()).toList());
     }
-
 
     _url = 'helloListOfListOfClass';
 
@@ -174,7 +173,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.Map<core.String, core.int>> helloMap(core.Map<core.String, core.int> request) {
     var _url = null;
@@ -187,7 +186,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloMap';
 
@@ -214,7 +212,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloNameAge(core.String name, core.int age) {
     var _url = null;
@@ -230,7 +228,6 @@ class ToyApi {
     if (age == null) {
       throw new core.ArgumentError("Parameter age is required.");
     }
-
 
     _url = 'hello/' + commons.Escaper.ecapeVariable('$name') + '/age/' + commons.Escaper.ecapeVariable('$age');
 
@@ -257,7 +254,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloNamePostAge(ToyAgeRequest request, core.String name) {
     var _url = null;
@@ -273,7 +270,6 @@ class ToyApi {
     if (name == null) {
       throw new core.ArgumentError("Parameter name is required.");
     }
-
 
     _url = 'helloPost/' + commons.Escaper.ecapeVariable('$name');
 
@@ -302,7 +298,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloNameQueryAgeFoo(core.String name, {core.String foo, core.int age}) {
     var _url = null;
@@ -321,7 +317,6 @@ class ToyApi {
     if (age != null) {
       _queryParams["age"] = ["${age}"];
     }
-
 
     _url = 'helloQuery/' + commons.Escaper.ecapeVariable('$name');
 
@@ -346,7 +341,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.List<core.List<core.String>>> helloNestedListList(core.List<core.List<core.int>> request) {
     var _url = null;
@@ -359,7 +354,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedListList';
 
@@ -385,7 +379,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.List<core.Map<core.String, core.List<core.String>>>> helloNestedListMapList(core.List<core.Map<core.String, core.List<core.int>>> request) {
     var _url = null;
@@ -398,7 +392,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedListMapList';
 
@@ -421,7 +414,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyMapResponse> helloNestedMap() {
     var _url = null;
@@ -430,7 +423,6 @@ class ToyApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'helloNestedMap';
@@ -457,7 +449,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.Map<core.String, core.List<core.Map<core.String, core.bool>>>> helloNestedMapListMap(core.Map<core.String, core.List<core.Map<core.String, core.int>>> request) {
     var _url = null;
@@ -470,7 +462,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedMapListMap';
 
@@ -495,7 +486,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.Map<core.String, core.Map<core.String, core.bool>>> helloNestedMapMap(core.Map<core.String, core.Map<core.String, core.int>> request) {
     var _url = null;
@@ -508,7 +499,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedMapMap';
 
@@ -533,7 +523,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloPost(ToyRequest request) {
     var _url = null;
@@ -546,7 +536,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(ToyRequestFactory.toJson(request));
     }
-
 
     _url = 'helloPost';
 
@@ -569,7 +558,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloReturnNull() {
     var _url = null;
@@ -578,7 +567,6 @@ class ToyApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'helloReturnNull';
@@ -602,7 +590,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloVoid() {
     var _url = null;
@@ -611,7 +599,6 @@ class ToyApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'helloVoid';
@@ -633,7 +620,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future noop() {
     var _url = null;
@@ -669,7 +656,7 @@ class ToyApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<core.List<core.String>> reverseList(core.List<core.String> request) {
     var _url = null;
@@ -682,7 +669,6 @@ class ToyApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'reverseList';
 
@@ -718,7 +704,7 @@ class ComputeResourceApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResourceResponse> get(core.String resource, core.String compute) {
     var _url = null;
@@ -734,7 +720,6 @@ class ComputeResourceApi {
     if (compute == null) {
       throw new core.ArgumentError("Parameter compute is required.");
     }
-
 
     _url = 'toyresource/' + commons.Escaper.ecapeVariable('$resource') + '/compute/' + commons.Escaper.ecapeVariable('$compute');
 
@@ -770,7 +755,7 @@ class StorageResourceApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResourceResponse> get(core.String resource, core.String storage) {
     var _url = null;
@@ -786,7 +771,6 @@ class StorageResourceApi {
     if (storage == null) {
       throw new core.ArgumentError("Parameter storage is required.");
     }
-
 
     _url = 'toyresource/' + commons.Escaper.ecapeVariable('$resource') + '/storage/' + commons.Escaper.ecapeVariable('$storage');
 
@@ -822,7 +806,6 @@ class NestedResponseFactory {
   }
 }
 
-
 class ToyAgeRequestFactory {
   static ToyAgeRequest fromJson(core.Map _json) {
     var message = new ToyAgeRequest();
@@ -840,7 +823,6 @@ class ToyAgeRequestFactory {
     return _json;
   }
 }
-
 
 class ToyMapResponseFactory {
   static ToyMapResponse fromJson(core.Map _json) {
@@ -866,7 +848,6 @@ class ToyMapResponseFactory {
   }
 }
 
-
 class ToyRequestFactory {
   static ToyRequest fromJson(core.Map _json) {
     var message = new ToyRequest();
@@ -891,7 +872,6 @@ class ToyRequestFactory {
   }
 }
 
-
 class ToyResourceResponseFactory {
   static ToyResourceResponse fromJson(core.Map _json) {
     var message = new ToyResourceResponse();
@@ -910,7 +890,6 @@ class ToyResourceResponseFactory {
   }
 }
 
-
 class ToyResponseFactory {
   static ToyResponse fromJson(core.Map _json) {
     var message = new ToyResponse();
@@ -928,5 +907,3 @@ class ToyResponseFactory {
     return _json;
   }
 }
-
-

--- a/test/src/data/expected_identical.dartt
+++ b/test/src/data/expected_identical.dartt
@@ -1,12 +1,10 @@
 library discoveryapis_tests.toyApi.client;
 
 import 'dart:core' as core;
-import 'dart:collection' as collection;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
-import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 import 'package:discoveryapis-tests/messages.dart';
 export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -3,12 +3,10 @@
 library discoveryapis_tests.toyApi.D0_1;
 
 import 'dart:core' as core;
-import 'dart:collection' as collection;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
-import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 
 export 'package:_discoveryapis_commons/_discoveryapis_commons.dart' show

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -3,6 +3,7 @@
 library discoveryapis_tests.toyApi.D0_1;
 
 import 'dart:core' as core;
+import 'dart:collection' as collection;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
 
@@ -31,7 +32,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future failing() {
     var _url = null;
@@ -65,7 +66,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> hello() {
     var _url = null;
@@ -74,7 +75,6 @@ class ToyApiApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'hello';
@@ -100,7 +100,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<MapOfToyResponse> helloListOfClass(ListOfToyRequest request) {
     var _url = null;
@@ -113,7 +113,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode((request).toJson());
     }
-
 
     _url = 'helloListOfClass';
 
@@ -138,7 +137,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<MapOfToyResponse> helloListOfListOfClass(ListOfListOfToyRequest request) {
     var _url = null;
@@ -151,7 +150,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode((request).toJson());
     }
-
 
     _url = 'helloListOfListOfClass';
 
@@ -176,7 +174,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<MapOfint> helloMap(MapOfint request) {
     var _url = null;
@@ -189,7 +187,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloMap';
 
@@ -216,7 +213,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloNameAge(core.String name, core.int age) {
     var _url = null;
@@ -232,7 +229,6 @@ class ToyApiApi {
     if (age == null) {
       throw new core.ArgumentError("Parameter age is required.");
     }
-
 
     _url = 'hello/' + commons.Escaper.ecapeVariable('$name') + '/age/' + commons.Escaper.ecapeVariable('$age');
 
@@ -259,7 +255,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloNamePostAge(ToyAgeRequest request, core.String name) {
     var _url = null;
@@ -275,7 +271,6 @@ class ToyApiApi {
     if (name == null) {
       throw new core.ArgumentError("Parameter name is required.");
     }
-
 
     _url = 'helloPost/' + commons.Escaper.ecapeVariable('$name');
 
@@ -304,7 +299,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloNameQueryAgeFoo(core.String name, {core.String foo, core.int age}) {
     var _url = null;
@@ -323,7 +318,6 @@ class ToyApiApi {
     if (age != null) {
       _queryParams["age"] = ["${age}"];
     }
-
 
     _url = 'helloQuery/' + commons.Escaper.ecapeVariable('$name');
 
@@ -348,7 +342,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ListOfListOfString> helloNestedListList(ListOfListOfint request) {
     var _url = null;
@@ -361,7 +355,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedListList';
 
@@ -386,7 +379,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ListOfMapOfListOfString> helloNestedListMapList(ListOfMapOfListOfint request) {
     var _url = null;
@@ -399,7 +392,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedListMapList';
 
@@ -422,7 +414,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyMapResponse> helloNestedMap() {
     var _url = null;
@@ -431,7 +423,6 @@ class ToyApiApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'helloNestedMap';
@@ -457,7 +448,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<MapOfListOfMapOfbool> helloNestedMapListMap(MapOfListOfMapOfint request) {
     var _url = null;
@@ -470,7 +461,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedMapListMap';
 
@@ -495,7 +485,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<MapOfMapOfbool> helloNestedMapMap(MapOfMapOfint request) {
     var _url = null;
@@ -508,7 +498,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'helloNestedMapMap';
 
@@ -533,7 +522,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloPost(ToyRequest request) {
     var _url = null;
@@ -546,7 +535,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode((request).toJson());
     }
-
 
     _url = 'helloPost';
 
@@ -569,7 +557,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloReturnNull() {
     var _url = null;
@@ -578,7 +566,6 @@ class ToyApiApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'helloReturnNull';
@@ -602,7 +589,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResponse> helloVoid() {
     var _url = null;
@@ -611,7 +598,6 @@ class ToyApiApi {
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
     var _body = null;
-
 
 
     _url = 'helloVoid';
@@ -633,7 +619,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future noop() {
     var _url = null;
@@ -669,7 +655,7 @@ class ToyApiApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ListOfString> reverseList(ListOfString request) {
     var _url = null;
@@ -682,7 +668,6 @@ class ToyApiApi {
     if (request != null) {
       _body = convert.JSON.encode(request);
     }
-
 
     _url = 'reverseList';
 
@@ -718,7 +703,7 @@ class ComputeResourceApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResourceResponse> get(core.String resource, core.String compute) {
     var _url = null;
@@ -734,7 +719,6 @@ class ComputeResourceApi {
     if (compute == null) {
       throw new core.ArgumentError("Parameter compute is required.");
     }
-
 
     _url = 'toyresource/' + commons.Escaper.ecapeVariable('$resource') + '/compute/' + commons.Escaper.ecapeVariable('$compute');
 
@@ -770,7 +754,7 @@ class StorageResourceApi {
    * error.
    *
    * If the used [http.Client] completes with an error when making a REST call,
-   * this method  will complete with the same error.
+   * this method will complete with the same error.
    */
   async.Future<ToyResourceResponse> get(core.String resource, core.String storage) {
     var _url = null;
@@ -786,7 +770,6 @@ class StorageResourceApi {
     if (storage == null) {
       throw new core.ArgumentError("Parameter storage is required.");
     }
-
 
     _url = 'toyresource/' + commons.Escaper.ecapeVariable('$resource') + '/storage/' + commons.Escaper.ecapeVariable('$storage');
 
@@ -830,7 +813,6 @@ class ListOfListOfString
   }
 }
 
-
 class ListOfListOfToyRequest
     extends collection.ListBase<core.List<ToyRequest>> {
   final core.List<core.List<ToyRequest>> _inner;
@@ -856,7 +838,6 @@ class ListOfListOfToyRequest
     _inner.length = newLength;
   }
 }
-
 
 class ListOfListOfint
     extends collection.ListBase<core.List<core.int>> {
@@ -884,7 +865,6 @@ class ListOfListOfint
   }
 }
 
-
 class ListOfMapOfListOfString
     extends collection.ListBase<core.Map<core.String, core.List<core.String>>> {
   final core.List<core.Map<core.String, core.List<core.String>>> _inner;
@@ -910,7 +890,6 @@ class ListOfMapOfListOfString
     _inner.length = newLength;
   }
 }
-
 
 class ListOfMapOfListOfint
     extends collection.ListBase<core.Map<core.String, core.List<core.int>>> {
@@ -938,7 +917,6 @@ class ListOfMapOfListOfint
   }
 }
 
-
 class ListOfString
     extends collection.ListBase<core.String> {
   final core.List<core.String> _inner;
@@ -965,7 +943,6 @@ class ListOfString
   }
 }
 
-
 class ListOfToyRequest
     extends collection.ListBase<ToyRequest> {
   final core.List<ToyRequest> _inner;
@@ -991,7 +968,6 @@ class ListOfToyRequest
     _inner.length = newLength;
   }
 }
-
 
 class MapOfListOfMapOfbool
     extends collection.MapBase<core.String, core.List<core.Map<core.String, core.bool>>> {
@@ -1029,7 +1005,6 @@ class MapOfListOfMapOfbool
   core.List<core.Map<core.String, core.bool>> remove(core.Object key) => _innerMap.remove(key);
 }
 
-
 class MapOfListOfMapOfint
     extends collection.MapBase<core.String, core.List<core.Map<core.String, core.int>>> {
   final core.Map _innerMap = {};
@@ -1065,7 +1040,6 @@ class MapOfListOfMapOfint
 
   core.List<core.Map<core.String, core.int>> remove(core.Object key) => _innerMap.remove(key);
 }
-
 
 class MapOfMapOfbool
     extends collection.MapBase<core.String, core.Map<core.String, core.bool>> {
@@ -1103,7 +1077,6 @@ class MapOfMapOfbool
   core.Map<core.String, core.bool> remove(core.Object key) => _innerMap.remove(key);
 }
 
-
 class MapOfMapOfint
     extends collection.MapBase<core.String, core.Map<core.String, core.int>> {
   final core.Map _innerMap = {};
@@ -1139,7 +1112,6 @@ class MapOfMapOfint
 
   core.Map<core.String, core.int> remove(core.Object key) => _innerMap.remove(key);
 }
-
 
 class MapOfToyResponse
     extends collection.MapBase<core.String, ToyResponse> {
@@ -1177,7 +1149,6 @@ class MapOfToyResponse
   ToyResponse remove(core.Object key) => _innerMap.remove(key);
 }
 
-
 class MapOfint
     extends collection.MapBase<core.String, core.int> {
   final core.Map _innerMap = {};
@@ -1214,10 +1185,8 @@ class MapOfint
   core.int remove(core.Object key) => _innerMap.remove(key);
 }
 
-
 class NestedResponse {
   core.String nestedResult;
-
 
   NestedResponse();
 
@@ -1236,10 +1205,8 @@ class NestedResponse {
   }
 }
 
-
 class ToyAgeRequest {
   core.int age;
-
 
   ToyAgeRequest();
 
@@ -1258,12 +1225,9 @@ class ToyAgeRequest {
   }
 }
 
-
 class ToyMapResponse {
   core.Map<core.String, NestedResponse> mapResult;
-
   core.String result;
-
 
   ToyMapResponse();
 
@@ -1288,12 +1252,9 @@ class ToyMapResponse {
   }
 }
 
-
 class ToyRequest {
   core.int age;
-
   core.String name;
-
 
   ToyRequest();
 
@@ -1318,10 +1279,8 @@ class ToyRequest {
   }
 }
 
-
 class ToyResourceResponse {
   core.String result;
-
 
   ToyResourceResponse();
 
@@ -1340,10 +1299,8 @@ class ToyResourceResponse {
   }
 }
 
-
 class ToyResponse {
   core.String result;
-
 
   ToyResponse();
 

--- a/test/src/namer_test.dart
+++ b/test/src/namer_test.dart
@@ -166,6 +166,22 @@ main() {
         childNamer.nameIdentifier(b);
         expect(b.name, equals('b_1'));
       });
+
+      test('wasCalled', () {
+        Identifier id = new Identifier('foo');
+        expect(id.wasCalled, false);
+        id.ref();
+        expect(id.wasCalled, true);
+        id.resetCallCount();
+        expect(id.wasCalled, false);
+      });
+
+      test('Identifier.noPrefix()', () {
+        Identifier id = new Identifier.noPrefix();
+        expect(id.ref(), '');
+        // Test that toString() doesn't throw.
+        expect(id.toString(), null);
+      });
     });
 
     group('api-namer', () {

--- a/test/src/namer_test.dart
+++ b/test/src/namer_test.dart
@@ -172,8 +172,6 @@ main() {
         expect(id.wasCalled, false);
         id.ref();
         expect(id.wasCalled, true);
-        id.resetCallCount();
-        expect(id.wasCalled, false);
       });
 
       test('Identifier.noPrefix()', () {

--- a/tool/hop_runner.dart
+++ b/tool/hop_runner.dart
@@ -20,7 +20,7 @@ void main(List<String> args) {
       'files',
       '--input-dir=example',
       '--output-dir=example',
-      '--no-core-prefix'
+      '--no-core-prefixes'
     ])
   ]));
 

--- a/tool/hop_runner.dart
+++ b/tool/hop_runner.dart
@@ -19,7 +19,8 @@ void main(List<String> args) {
       'bin/generate.dart',
       'files',
       '--input-dir=example',
-      '--output-dir=example'
+      '--output-dir=example',
+      '--no-core-prefix'
     ])
   ]));
 


### PR DESCRIPTION
fix #139 
workaround for #141 

Add a cli option to remove the `core.` prefix for `dart:core`. User's can pass on `--no-core-prefix` to remove the prefix from generated code.

Also, only add imports for libraries that are referenced in the generated code. We count the number of times a library is used when generating code and only add an import if that library was used at least once. Added tests for the changes to `lib/src/namer.dart`.

You can see the changes in `example/dartservices.dart`.

@mkustermann, @wibling 