### PR TITLE
fix: use correct prefix for int.parse

### DIFF
--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -230,7 +230,7 @@ class StringIntegerType extends PrimitiveDartSchemaType {
 
   String get declaration => '${imports.core.ref()}int';
   String jsonEncode(String value) => '"\${${value}}"';
-  String jsonDecode(String json) => 'int.parse("\${${json}}")';
+  String jsonDecode(String json) => '${imports.core.ref()}int.parse("\${${json}}")';
 }
 
 


### PR DESCRIPTION
Sorry, I didn't expect my previous pull request to be merged right away.

I will spend more time with this code in the next days.  If there are more stupid bugs (which I don't expect) I should find them pretty soon.

need to prefix int.parse with ${imports.core.ref()}
