### PR TITLE
Remove unused imports from generated test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - discoveryapis_generator
 
+## v0.9.1
+
+- Avoid unused imports in generated tests.
+
 ## v0.9.0
 
 - Make generated code strong mode clean.

--- a/lib/src/dart_api_test_library.dart
+++ b/lib/src/dart_api_test_library.dart
@@ -95,12 +95,10 @@ class DartApiTestLibrary extends TestHelper {
 library ${apiLibrary.libraryName}.test;
 
 import "dart:core" as core;
-import "dart:collection" as collection;
 import "dart:async" as async;
 import "dart:convert" as convert;
 
 import 'package:http/http.dart' as http;
-import 'package:http/testing.dart' as http_testing;
 import 'package:test/test.dart' as unittest;
 
 import '$apiImportPath' as api;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discoveryapis_generator
-version: 0.9.0
+version: 0.9.1
 author: Dart Team <misc@dartlang.org>
 description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator


### PR DESCRIPTION
- "http_testing" does not show up anywhere else in the package so this
  import is unused.
- "collection" does not seem to show up as a prefix inside genered test
  code.