### PR TITLE
Go back to <2.0.0 sdk constraint (from <2.0.0-dev.infinity) after new guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - discoveryapis_generator
 
+## v0.9.1+1
+
+- Use `< 2.0.0` sdk constraint in generated `pubspec.yaml` files (following the
+  [new guideline](http://news.dartlang.org/2017/09/dart-20-pre-releases-what-they-mean-to.html)).
+
 ## v0.9.1
 
 - Avoid unused imports in generated tests.

--- a/lib/discoveryapis_generator.dart
+++ b/lib/discoveryapis_generator.dart
@@ -28,7 +28,7 @@ class Pubspec {
   Pubspec(this.name, this.version, this.description,
       {this.author, this.homepage});
 
-  String get sdkConstraint => '>=1.22.0 <2.0.0-dev.infinity';
+  String get sdkConstraint => '>=1.22.0 <2.0.0';
 
   static Map<String, Object> get dependencies => const {
         'http': '\'>=0.11.1 <0.12.0\'',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discoveryapis_generator
-version: 0.9.1
+version: 0.9.1+1
 author: Dart Team <misc@dartlang.org>
 description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator


### PR DESCRIPTION

The new [guidelines] say we should no longer use an infinity constraint.

[guidelines] http://news.dartlang.org/2017/09/dart-20-pre-releases-what-they-mean-to.html