### PR TITLE
Limit dart_style to <=1.0.9+1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: '>=0.12.1 <2.0.0'
-  dart_style: '>=1.0.7 <2.0.0'
+  dart_style: '>=1.0.7 <=1.0.9+1'
   http: '>=0.11.1 <0.12.0'
   path: '>=1.3.3 <2.0.0'
   yaml: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
The latest version of dart_style (1.0.10) depends on analyzer
0.31.2-alpha.0 which only supports SDK >=2.0.0-dev. Since we want to be
able to run on stable, we have to limit dart_style to 1.0.9+1.

In a perfect world, pub would automatically do this for us, but
unfortunately it doesn't (at least not in SDK 1.24.3). Instead, it spins
forever trying to solve the constraint puzzle.

Fixes #185