### PR TITLE
Fix type cast bug in dart 2’s strong mode

### DIFF
--- a/example/dartservices.dart
+++ b/example/dartservices.dart
@@ -369,7 +369,8 @@ class AnalysisResults {
     if (_json.containsKey("issues")) {
       issues = _json["issues"]
           .map((value) => new AnalysisIssue.fromJson(value))
-          .toList();
+          .toList()
+          .cast<AnalysisIssue>();
     }
   }
 

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -423,7 +423,7 @@ class UnnamedArrayType extends ComplexDartSchemaType {
   String jsonDecode(String json) {
     if (innerType.needsJsonDecoding) {
       return '${json}.map((value) => ${innerType.jsonDecode('value')})'
-          '.toList()';
+          '.toList().cast<${innerType.declaration}>()';
     } else {
       // NOTE: The List returned from JSON.decode() transfers ownership to the
       // user (i.e. we don't need to make a copy of it).

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -902,7 +902,7 @@ class ListOfListOfToyRequest
   ListOfListOfToyRequest.fromJson(core.List json)
       : _inner = json
             .map((value) =>
-                value.map((value) => new ToyRequest.fromJson(value)).toList())
+                value.map((value) => new ToyRequest.fromJson(value)).toList().cast<ToyRequest>())
             .toList();
 
   core.List<core.List<core.Map<core.String, core.Object>>> toJson() {


### PR DESCRIPTION
This PR fixes these errors in flutter application:

```
[VERBOSE-2:dart_error.cc(16)] Unhandled exception:
type 'List' is not a subtype of type 'List<Activity>' where
  List is from dart:core
  List is from dart:core
  Activity is from package:googleapis/youtube/v3.dart

#0      new ActivityListResponse.fromJson (package:googleapis/youtube/v3.dart:7334:71)
#1      ActivitiesResourceApi.list.<anonymous closure> (package:googleapis/youtube/v3.dart:291:41)
...
```

**Dart version:**

```
$ flutter --version
Flutter 0.2.4 • channel dev • https://github.com/flutter/flutter.git
Framework • revision 3352a3fb48 (7 days ago) • 2018-03-20 19:30:06 +0100
Engine • revision 6280adbfb1
Tools • Dart 2.0.0-dev.39.0.flutter-06949dc985
```

I regenerated googleapis code with this fix. It worked for my flutter app. I am not sure if there is a plan for making generated code fully support dart 2's strong mode. (https://github.com/jacobdam/googleapis/commit/5c3315f19f6897eb7388db4052e8e69c7ed9b764)