### PR TITLE
Dart 2 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dart_tool/
 .packages
 .pub/
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - discoveryapis_generator
 
+## v0.9.5
+
+- More type annotations for Dart 2.
+
 ## v0.9.4
 
 - Use type arguments for `Map`, since dynamic is no longer bottom.

--- a/example/dartservices.dart
+++ b/example/dartservices.dart
@@ -35,7 +35,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future<AnalysisResults> analyze(SourceRequest request) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -69,7 +69,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future<AnalysisResults> analyzeGet({String source}) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -103,7 +103,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future<CompileResponse> compile(SourceRequest request) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -137,7 +137,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future<CompileResponse> compileGet({String source}) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -169,7 +169,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future complete(SourceRequest request) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -205,7 +205,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future completeGet({String source, int offset}) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -244,7 +244,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future<DocumentResponse> document(SourceRequest request) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -280,7 +280,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   Future<DocumentResponse> documentGet({String source, int offset}) {
     var _url = null;
-    var _queryParams = new Map();
+    var _queryParams = new Map<String, List<String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -368,7 +368,7 @@ class AnalysisResults {
   AnalysisResults.fromJson(Map _json) {
     if (_json.containsKey("issues")) {
       issues = _json["issues"]
-          .map((value) => new AnalysisIssue.fromJson(value))
+          .map<AnalysisIssue>((value) => new AnalysisIssue.fromJson(value))
           .toList();
     }
   }

--- a/lib/src/dart_api_test_library.dart
+++ b/lib/src/dart_api_test_library.dart
@@ -266,7 +266,7 @@ class ResourceTest extends TestHelper {
             sb.write('(_) {}');
           } else {
             var t = apiTestLibrary.schemaTests[method.returnType];
-            sb.writeln('((api.${method.returnType.className} response) {');
+            sb.writeln('((response) {');
             sb.writeln('        ${t.checkSchemaStatement('response')}');
             sb.write('      })');
           }

--- a/lib/src/dart_resources.dart
+++ b/lib/src/dart_resources.dart
@@ -351,9 +351,10 @@ $urlPatternCode
     methodString.write(methodComment.asDartDoc(2));
     methodString.writeln('  $signature {');
 
+    final core = imports.core.ref();
     methodString.write('''
     var _url = null;
-    var _queryParams = new ${imports.core.ref()}Map();
+    var _queryParams = new ${core}Map<${core}String, ${core}List<${core}String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = ${imports.commons}.DownloadOptions.Metadata;

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -589,7 +589,7 @@ class NamedMapType extends ComplexDartSchemaType {
     var core = imports.core.ref();
     var decode = new StringBuffer();
     decode.writeln('  $className.fromJson(');
-    decode.writeln('      ${core}Map<${core}String, dynamic> _json) {');
+    decode.writeln('      ${core}Map<${core}String, ${core}dynamic> _json) {');
     decode.writeln('    _json.forEach((${core}String key, value) {');
     decode.writeln('      this[key] = ${toType.jsonDecode('value')};');
     decode.writeln('    });');

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -422,7 +422,7 @@ class UnnamedArrayType extends ComplexDartSchemaType {
 
   String jsonDecode(String json) {
     if (innerType.needsJsonDecoding) {
-      return '${json}.map((value) => ${innerType.jsonDecode('value')})'
+      return '${json}.map<${innerType.declaration}>((value) => ${innerType.jsonDecode('value')})'
           '.toList()';
     } else {
       // NOTE: The List returned from JSON.decode() transfers ownership to the

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -589,10 +589,8 @@ class NamedMapType extends ComplexDartSchemaType {
     var core = imports.core.ref();
     var decode = new StringBuffer();
     decode.writeln('  $className.fromJson(');
-    decode.writeln(
-        '      ${core}Map<${core}String, ${core}dynamic> _json) {');
-    decode.writeln(
-        '    _json.forEach((${core}String key, value) {');
+    decode.writeln('      ${core}Map<${core}String, dynamic> _json) {');
+    decode.writeln('    _json.forEach((${core}String key, value) {');
     decode.writeln('      this[key] = ${toType.jsonDecode('value')};');
     decode.writeln('    });');
     decode.writeln('  }');
@@ -602,8 +600,7 @@ class NamedMapType extends ComplexDartSchemaType {
     encode.writeln('    final ${jsonType.declaration} _json = '
         '<${fromType.jsonType.declaration}, '
         '${toType.jsonType.declaration}>{};');
-    encode
-        .writeln('    this.forEach((${core}String key, value) {');
+    encode.writeln('    this.forEach((${core}String key, value) {');
     encode.writeln('      _json[key] = ${toType.jsonEncode('value')};');
     encode.writeln('    });');
     encode.writeln('    return _json;');

--- a/lib/src/generated_googleapis/discovery/v1.dart
+++ b/lib/src/generated_googleapis/discovery/v1.dart
@@ -287,7 +287,8 @@ class DirectoryList {
     }
     if (_json.containsKey("items")) {
       items = _json["items"]
-          .map<DirectoryListItems>((value) => new DirectoryListItems.fromJson(value))
+          .map<DirectoryListItems>(
+              (value) => new DirectoryListItems.fromJson(value))
           .toList();
     }
     if (_json.containsKey("kind")) {
@@ -381,7 +382,8 @@ class JsonSchemaVariant {
     }
     if (_json.containsKey("map")) {
       map = _json["map"]
-          .map<JsonSchemaVariant>((value) => new JsonSchemaVariantMap.fromJson(value))
+          .map<JsonSchemaVariant>(
+              (value) => new JsonSchemaVariantMap.fromJson(value))
           .toList();
     }
   }

--- a/lib/src/generated_googleapis/discovery/v1.dart
+++ b/lib/src/generated_googleapis/discovery/v1.dart
@@ -46,7 +46,7 @@ class ApisResourceApi {
   /// this method  will complete with the same error.
   async.Future<RestDescription> getRest(core.String api, core.String version) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = common.DownloadOptions.Metadata;
@@ -287,7 +287,7 @@ class DirectoryList {
     }
     if (_json.containsKey("items")) {
       items = _json["items"]
-          .map((value) => new DirectoryListItems.fromJson(value))
+          .map<DirectoryListItems>((value) => new DirectoryListItems.fromJson(value))
           .toList();
     }
     if (_json.containsKey("kind")) {
@@ -381,7 +381,7 @@ class JsonSchemaVariant {
     }
     if (_json.containsKey("map")) {
       map = _json["map"]
-          .map((value) => new JsonSchemaVariantMap.fromJson(value))
+          .map<JsonSchemaVariant>((value) => new JsonSchemaVariantMap.fromJson(value))
           .toList();
     }
   }

--- a/lib/src/generated_googleapis/discovery/v1.dart
+++ b/lib/src/generated_googleapis/discovery/v1.dart
@@ -382,7 +382,7 @@ class JsonSchemaVariant {
     }
     if (_json.containsKey("map")) {
       map = _json["map"]
-          .map<JsonSchemaVariant>(
+          .map<JsonSchemaVariantMap>(
               (value) => new JsonSchemaVariantMap.fromJson(value))
           .toList();
     }

--- a/lib/src/generated_googleapis/src/common_internal.dart
+++ b/lib/src/generated_googleapis/src/common_internal.dart
@@ -568,7 +568,8 @@ class ResumableMediaUploader {
   ///
   /// Returns the returned [http.StreamedResponse] or completes with an error if
   /// the upload did not succeed. The response stream will not be listened to.
-  Future<http.StreamedResponse> _uploadChunk(Uri uri, ResumableChunk chunk, {bool lastChunk: false}) {
+  Future<http.StreamedResponse> _uploadChunk(Uri uri, ResumableChunk chunk,
+      {bool lastChunk: false}) {
     // If [uploadMedia.length] is null, we do not know the length.
     dynamic mediaTotalLength = _uploadMedia.length;
     if (mediaTotalLength == null || lastChunk) {

--- a/lib/src/generated_googleapis/src/common_internal.dart
+++ b/lib/src/generated_googleapis/src/common_internal.dart
@@ -39,7 +39,7 @@ class ApiRequester {
   /// Otherwise the result will be downloaded as a [common_external.Media]
   Future request(String requestUrl, String method,
       {String body,
-      Map queryParams,
+      Map<String, List<String>> queryParams,
       common_external.Media uploadMedia,
       common_external.UploadOptions uploadOptions,
       common_external.DownloadOptions downloadOptions:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discoveryapis_generator
-version: 0.9.4
+version: 0.9.5
 author: Dart Team <misc@dartlang.org>
 description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator

--- a/test/src/data/expected_identical.dartt
+++ b/test/src/data/expected_identical.dartt
@@ -38,7 +38,7 @@ class ToyApi {
   /// this method will complete with the same error.
   async.Future failing({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -75,7 +75,7 @@ class ToyApi {
   /// this method will complete with the same error.
   async.Future<ToyResponse> hello({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -114,7 +114,7 @@ class ToyApi {
       core.List<ToyRequest> request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -161,7 +161,7 @@ class ToyApi {
       core.List<core.List<ToyRequest>> request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -210,7 +210,7 @@ class ToyApi {
       core.Map<core.String, core.int> request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -253,7 +253,7 @@ class ToyApi {
   async.Future<ToyResponse> helloNameAge(core.String name, core.int age,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -303,7 +303,7 @@ class ToyApi {
       ToyAgeRequest request, core.String name,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -351,7 +351,7 @@ class ToyApi {
   async.Future<ToyResponse> helloNameQueryAgeFoo(core.String name,
       {core.String foo, core.int age, core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -399,7 +399,7 @@ class ToyApi {
       core.List<core.List<core.int>> request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -443,7 +443,7 @@ class ToyApi {
           core.List<core.Map<core.String, core.List<core.int>>> request,
           {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -481,7 +481,7 @@ class ToyApi {
   /// this method will complete with the same error.
   async.Future<ToyMapResponse> helloNestedMap({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -523,7 +523,7 @@ class ToyApi {
       core.Map<core.String, core.List<core.Map<core.String, core.int>>> request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -567,7 +567,7 @@ class ToyApi {
           core.Map<core.String, core.Map<core.String, core.int>> request,
           {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -608,7 +608,7 @@ class ToyApi {
   async.Future<ToyResponse> helloPost(ToyRequest request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -646,7 +646,7 @@ class ToyApi {
   /// this method will complete with the same error.
   async.Future<ToyResponse> helloReturnNull({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -681,7 +681,7 @@ class ToyApi {
   /// this method will complete with the same error.
   async.Future<ToyResponse> helloVoid({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -714,7 +714,7 @@ class ToyApi {
   /// this method will complete with the same error.
   async.Future noop({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -755,7 +755,7 @@ class ToyApi {
       core.List<core.String> request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -805,7 +805,7 @@ class ComputeResourceApi {
       core.String resource, core.String compute,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -861,7 +861,7 @@ class StorageResourceApi {
       core.String resource, core.String storage,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -1061,7 +1061,7 @@ class MapOfListOfMapOfbool extends collection
 
   MapOfListOfMapOfbool();
 
-  MapOfListOfMapOfbool.fromJson(core.Map<core.String, dynamic> _json) {
+  MapOfListOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1100,7 +1100,7 @@ class MapOfListOfMapOfint extends collection
 
   MapOfListOfMapOfint();
 
-  MapOfListOfMapOfint.fromJson(core.Map<core.String, dynamic> _json) {
+  MapOfListOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1139,7 +1139,7 @@ class MapOfMapOfbool
 
   MapOfMapOfbool();
 
-  MapOfMapOfbool.fromJson(core.Map<core.String, dynamic> _json) {
+  MapOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1177,7 +1177,7 @@ class MapOfMapOfint
 
   MapOfMapOfint();
 
-  MapOfMapOfint.fromJson(core.Map<core.String, dynamic> _json) {
+  MapOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1214,7 +1214,7 @@ class MapOfToyResponse extends collection.MapBase<core.String, ToyResponse> {
 
   MapOfToyResponse();
 
-  MapOfToyResponse.fromJson(core.Map<core.String, dynamic> _json) {
+  MapOfToyResponse.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = new ToyResponse.fromJson(value);
     });
@@ -1249,7 +1249,7 @@ class MapOfint extends collection.MapBase<core.String, core.int> {
 
   MapOfint();
 
-  MapOfint.fromJson(core.Map<core.String, dynamic> _json) {
+  MapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -1061,7 +1061,7 @@ class MapOfListOfMapOfbool extends collection
 
   MapOfListOfMapOfbool();
 
-  MapOfListOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfListOfMapOfbool.fromJson(core.Map<core.String, dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1100,7 +1100,7 @@ class MapOfListOfMapOfint extends collection
 
   MapOfListOfMapOfint();
 
-  MapOfListOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfListOfMapOfint.fromJson(core.Map<core.String, dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1139,7 +1139,7 @@ class MapOfMapOfbool
 
   MapOfMapOfbool();
 
-  MapOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfMapOfbool.fromJson(core.Map<core.String, dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1177,7 +1177,7 @@ class MapOfMapOfint
 
   MapOfMapOfint();
 
-  MapOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfMapOfint.fromJson(core.Map<core.String, dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1214,7 +1214,7 @@ class MapOfToyResponse extends collection.MapBase<core.String, ToyResponse> {
 
   MapOfToyResponse();
 
-  MapOfToyResponse.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfToyResponse.fromJson(core.Map<core.String, dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = new ToyResponse.fromJson(value);
     });
@@ -1249,7 +1249,7 @@ class MapOfint extends collection.MapBase<core.String, core.int> {
 
   MapOfint();
 
-  MapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfint.fromJson(core.Map<core.String, dynamic> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -39,7 +39,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future failing({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -76,7 +76,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future<ToyResponse> hello({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -114,7 +114,7 @@ class ToyApiApi {
   async.Future<MapOfToyResponse> helloListOfClass(ListOfToyRequest request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -156,7 +156,7 @@ class ToyApiApi {
       ListOfListOfToyRequest request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -196,7 +196,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future<MapOfint> helloMap(MapOfint request, {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -239,7 +239,7 @@ class ToyApiApi {
   async.Future<ToyResponse> helloNameAge(core.String name, core.int age,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -289,7 +289,7 @@ class ToyApiApi {
       ToyAgeRequest request, core.String name,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -337,7 +337,7 @@ class ToyApiApi {
   async.Future<ToyResponse> helloNameQueryAgeFoo(core.String name,
       {core.String foo, core.int age, core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -384,7 +384,7 @@ class ToyApiApi {
   async.Future<ListOfListOfString> helloNestedListList(ListOfListOfint request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -426,7 +426,7 @@ class ToyApiApi {
       ListOfMapOfListOfint request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -464,7 +464,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future<ToyMapResponse> helloNestedMap({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -503,7 +503,7 @@ class ToyApiApi {
       MapOfListOfMapOfint request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -544,7 +544,7 @@ class ToyApiApi {
   async.Future<MapOfMapOfbool> helloNestedMapMap(MapOfMapOfint request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -585,7 +585,7 @@ class ToyApiApi {
   async.Future<ToyResponse> helloPost(ToyRequest request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -623,7 +623,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future<ToyResponse> helloReturnNull({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -658,7 +658,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future<ToyResponse> helloVoid({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -691,7 +691,7 @@ class ToyApiApi {
   /// this method will complete with the same error.
   async.Future noop({core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -731,7 +731,7 @@ class ToyApiApi {
   async.Future<ListOfString> reverseList(ListOfString request,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -781,7 +781,7 @@ class ComputeResourceApi {
       core.String resource, core.String compute,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -837,7 +837,7 @@ class StorageResourceApi {
       core.String resource, core.String storage,
       {core.String $fields}) {
     var _url = null;
-    var _queryParams = new core.Map();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -902,7 +902,7 @@ class ListOfListOfToyRequest
   ListOfListOfToyRequest.fromJson(core.List json)
       : _inner = json
             .map((value) =>
-                value.map((value) => new ToyRequest.fromJson(value)).toList())
+                value.map<ToyRequest>((value) => new ToyRequest.fromJson(value)).toList())
             .toList();
 
   core.List<core.List<core.Map<core.String, core.Object>>> toJson() {


### PR DESCRIPTION
Add type to map() operation, so the created list has correct runtime type. Added types to created queryParams map.