### PR TITLE
Use core.Object instead of core.dynamic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - discoveryapis_generator
 
+## v0.9.6
+
+- Use core.Object instead of core.dynamic to avoid running into
+  dart-lang/sdk#29125.
+
 ## v0.9.5
 
 - More type annotations for Dart 2.

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -589,7 +589,7 @@ class NamedMapType extends ComplexDartSchemaType {
     var core = imports.core.ref();
     var decode = new StringBuffer();
     decode.writeln('  $className.fromJson(');
-    decode.writeln('      ${core}Map<${core}String, ${core}dynamic> _json) {');
+    decode.writeln('      ${core}Map<${core}String, ${core}Object> _json) {');
     decode.writeln('    _json.forEach((${core}String key, value) {');
     decode.writeln('      this[key] = ${toType.jsonDecode('value')};');
     decode.writeln('    });');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discoveryapis_generator
-version: 0.9.5
+version: 0.9.6
 author: Dart Team <misc@dartlang.org>
 description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -1061,7 +1061,7 @@ class MapOfListOfMapOfbool extends collection
 
   MapOfListOfMapOfbool();
 
-  MapOfListOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfListOfMapOfbool.fromJson(core.Map<core.String, core.Object> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1100,7 +1100,7 @@ class MapOfListOfMapOfint extends collection
 
   MapOfListOfMapOfint();
 
-  MapOfListOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfListOfMapOfint.fromJson(core.Map<core.String, core.Object> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1139,7 +1139,7 @@ class MapOfMapOfbool
 
   MapOfMapOfbool();
 
-  MapOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfMapOfbool.fromJson(core.Map<core.String, core.Object> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1177,7 +1177,7 @@ class MapOfMapOfint
 
   MapOfMapOfint();
 
-  MapOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfMapOfint.fromJson(core.Map<core.String, core.Object> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });
@@ -1214,7 +1214,7 @@ class MapOfToyResponse extends collection.MapBase<core.String, ToyResponse> {
 
   MapOfToyResponse();
 
-  MapOfToyResponse.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfToyResponse.fromJson(core.Map<core.String, core.Object> _json) {
     _json.forEach((core.String key, value) {
       this[key] = new ToyResponse.fromJson(value);
     });
@@ -1249,7 +1249,7 @@ class MapOfint extends collection.MapBase<core.String, core.int> {
 
   MapOfint();
 
-  MapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
+  MapOfint.fromJson(core.Map<core.String, core.Object> _json) {
     _json.forEach((core.String key, value) {
       this[key] = value;
     });


### PR DESCRIPTION
The different tools and runtimes still don't agree on whether dynamic is
exported by dart:core (see dart-lang/sdk#29125). To work around this, we
use core.Object instead.