### PR TITLE
More Dart 2 fixes for generated code.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: dart
 dart:
-  - stable
   - dev
 script: ./tool/travis.sh
 # Use container based builds.

--- a/example/dartservices.dart
+++ b/example/dartservices.dart
@@ -42,7 +42,7 @@ class DartservicesApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
 
     _url = 'analyze';
@@ -110,7 +110,7 @@ class DartservicesApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
 
     _url = 'compile';
@@ -176,7 +176,7 @@ class DartservicesApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
 
     _downloadOptions = null;
@@ -251,7 +251,7 @@ class DartservicesApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
 
     _url = 'document';
@@ -409,7 +409,7 @@ class DocumentResponse {
 
   DocumentResponse.fromJson(Map _json) {
     if (_json.containsKey("info")) {
-      info = _json["info"];
+      info = (_json["info"] as Map).cast();
     }
   }
 

--- a/example/dartservices.dart
+++ b/example/dartservices.dart
@@ -367,7 +367,7 @@ class AnalysisResults {
 
   AnalysisResults.fromJson(Map _json) {
     if (_json.containsKey("issues")) {
-      issues = _json["issues"]
+      issues = (_json["issues"] as List)
           .map<AnalysisIssue>((value) => new AnalysisIssue.fromJson(value))
           .toList();
     }
@@ -409,7 +409,7 @@ class DocumentResponse {
 
   DocumentResponse.fromJson(Map _json) {
     if (_json.containsKey("info")) {
-      info = (_json["info"] as Map).cast();
+      info = (_json["info"] as Map).cast<String, String>();
     }
   }
 

--- a/lib/discoveryapis_generator.dart
+++ b/lib/discoveryapis_generator.dart
@@ -26,7 +26,7 @@ class Pubspec {
   Pubspec(this.name, this.version, this.description,
       {this.author, this.homepage});
 
-  String get sdkConstraint => '>=1.22.0 <2.0.0';
+  String get sdkConstraint => '>=2.0.0-dev.22.0 <2.0.0';
 
   static Map<String, Object> get dependencies => const {
         'http': '\'>=0.11.1 <0.12.0\'',
@@ -53,7 +53,7 @@ List<GenerateResult> generateAllLibraries(
       .where((fse) => fse is File && fse.path.endsWith('.json'))
       .map((FileSystemEntity entity) {
     return new RestDescription.fromJson(
-        JSON.decode((entity as File).readAsStringSync()));
+        json.decode((entity as File).readAsStringSync()));
   }).toList();
   return generateApiPackage(apiDescriptions, outputDirectory, pubspec);
 }

--- a/lib/src/apis_files_generator.dart
+++ b/lib/src/apis_files_generator.dart
@@ -64,7 +64,7 @@ class ApisFilesGenerator {
     var results = <GenerateResult>[];
     descriptions.forEach((diPair) {
       var description =
-          new RestDescription.fromJson(JSON.decode(diPair.apiDescription));
+          new RestDescription.fromJson(json.decode(diPair.apiDescription));
       String name = description.name.toLowerCase();
       String version = description.version.toLowerCase();
       String apiFile = path.join(clientFolderPath, '${name}.dart');

--- a/lib/src/dart_api_test_library.dart
+++ b/lib/src/dart_api_test_library.dart
@@ -111,13 +111,13 @@ class HttpServerMock extends http.BaseClient {
   async.Future<http.StreamedResponse> send(http.BaseRequest request) {
     if (_expectJson) {
       return request.finalize()
-          .transform(convert.UTF8.decoder)
+          .transform(convert.utf8.decoder)
           .join('')
           .then((core.String jsonString) {
         if (jsonString.isEmpty) {
           return _callback(request, null);
         } else {
-          return _callback(request, convert.JSON.decode(jsonString));
+          return _callback(request, convert.json.decode(jsonString));
         }
       });
     } else {
@@ -135,7 +135,7 @@ class HttpServerMock extends http.BaseClient {
 
 http.StreamedResponse stringResponse(
     core.int status, core.Map<core.String, core.String> headers, core.String body) {
-  var stream = new async.Stream.fromIterable([convert.UTF8.encode(body)]);
+  var stream = new async.Stream.fromIterable([convert.utf8.encode(body)]);
   return new http.StreamedResponse(stream, status, headers: headers);
 }
 """;
@@ -200,7 +200,7 @@ class ResourceTest extends TestHelper {
             } else {
               var t = apiTestLibrary.schemaTests[method.returnType];
               sb.writeln('        var resp = '
-                  'convert.JSON.encode(${t.newSchemaExpr});');
+                  'convert.json.encode(${t.newSchemaExpr});');
             }
             sb.writeln('        return new async.Future.value('
                 'stringResponse(200, h, resp));');
@@ -377,7 +377,7 @@ class MethodArgsTest extends TestHelper {
 
     ln('var query = ${uriExpr}.query;');
     ln('var queryOffset = 0;');
-    ln('var queryMap = {};');
+    ln('var queryMap = <core.String, core.List<core.String>>{};');
     ln('addQueryParam(n, v) => queryMap.putIfAbsent(n, () => []).add(v);');
     ln('parseBool(n) {');
     ln('  if (n == "true") return true;');

--- a/lib/src/dart_resources.dart
+++ b/lib/src/dart_resources.dart
@@ -206,7 +206,7 @@ class DartResourceMethod {
           requestParameter.type.jsonEncode('${requestParameter.name}');
       params.writeln('    if (${requestParameter.name} != null) {');
       params.writeln(
-          '      _body = ${imports.convert.ref()}JSON.encode(${parameterEncode});');
+          '      _body = ${imports.convert.ref()}json.encode(${parameterEncode});');
       params.writeln('    }');
     }
 

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -556,7 +556,7 @@ class UnnamedMapType extends ComplexDartSchemaType {
     if (fromType.needsJsonDecoding || toType.needsJsonDecoding) {
       return '${imports.commons}.mapMap'
           '<${toType.jsonType.baseDeclaration}, ${toType.declaration}>'
-          '($json.cast<${imports.core.ref()}String, ${toType.jsonType.baseDeclaration}>(), '
+          '($json.cast<${fromType.jsonType.baseDeclaration}, ${toType.jsonType.baseDeclaration}>(), '
           '(${toType.jsonType.baseDeclaration} item) '
           '=> ${toType.jsonDecode('item')})';
     } else {

--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -79,6 +79,7 @@ abstract class JsonType {
   JsonType(this.imports);
 
   String get declaration;
+  String get baseDeclaration => declaration;
 }
 
 class SimpleJsonType extends JsonType {
@@ -116,6 +117,8 @@ class MapJsonType extends JsonType {
     return '${imports.core.ref()}Map'
         '<${keyJsonType.declaration}, ${valueJsonType.declaration}>';
   }
+
+  String get baseDeclaration => '${imports.core.ref()}Map';
 }
 
 class ArrayJsonType extends JsonType {
@@ -125,6 +128,8 @@ class ArrayJsonType extends JsonType {
 
   String get declaration =>
       '${imports.core.ref()}List<${valueJsonType.declaration}>';
+
+  String get baseDeclaration => '${imports.core.ref()}List';
 }
 
 class AnyJsonType extends JsonType {
@@ -422,12 +427,12 @@ class UnnamedArrayType extends ComplexDartSchemaType {
 
   String jsonDecode(String json) {
     if (innerType.needsJsonDecoding) {
-      return '${json}.map<${innerType.declaration}>((value) => ${innerType.jsonDecode('value')})'
+      return '($json as ${imports.core.ref()}List).map<${innerType.declaration}>((value) => ${innerType.jsonDecode('value')})'
           '.toList()';
     } else {
       // NOTE: The List returned from JSON.decode() transfers ownership to the
       // user (i.e. we don't need to make a copy of it).
-      return json;
+      return '($json as ${imports.core.ref()}List).cast<${innerType.declaration}>()';
     }
   }
 }
@@ -550,13 +555,14 @@ class UnnamedMapType extends ComplexDartSchemaType {
   String jsonDecode(String json) {
     if (fromType.needsJsonDecoding || toType.needsJsonDecoding) {
       return '${imports.commons}.mapMap'
-          '<${toType.jsonType.declaration}, ${toType.declaration}>'
-          '(${json}, (${toType.jsonType.declaration} item) '
+          '<${toType.jsonType.baseDeclaration}, ${toType.declaration}>'
+          '($json.cast<${imports.core.ref()}String, ${toType.jsonType.baseDeclaration}>(), '
+          '(${toType.jsonType.baseDeclaration} item) '
           '=> ${toType.jsonDecode('item')})';
     } else {
       // NOTE: The Map returned from JSON.decode() transfers ownership to the
       // user (i.e. we don't need to make a copy of it).
-      return json;
+      return '($json as ${imports.core.ref()}Map).cast<${fromType.declaration}, ${toType.declaration}>()';
     }
   }
 }
@@ -612,7 +618,7 @@ class NamedMapType extends ComplexDartSchemaType {
     return '''
 ${comment.asDartDoc(0)}class $className
     extends ${imports.collection.ref()}MapBase<$fromT, $toT> {
-  final ${core}Map _innerMap = {};
+  final _innerMap = <$fromT, $toT>{};
 
   $className();
 
@@ -703,7 +709,7 @@ class ObjectType extends ComplexDartSchemaType {
             '  ${imports.core.ref()}List<${imports.core.ref()}int> get '
             '${property.byteArrayAccessor} {');
         propertyString.writeln('    return '
-            '${imports.convert.ref()}BASE64.decode'
+            '${imports.convert.ref()}base64.decode'
             '(${property.name});');
         propertyString.writeln('  }');
 
@@ -713,7 +719,7 @@ class ObjectType extends ComplexDartSchemaType {
         propertyString.writeln(
             '(${imports.core.ref()}List<${imports.core.ref()}int> _bytes) {');
         propertyString.writeln('    ${property.name} = ${imports.convert.ref()}'
-            'BASE64.encode(_bytes).replaceAll("/", "_").replaceAll("+", "-");');
+            'base64.encode(_bytes).replaceAll("/", "_").replaceAll("+", "-");');
         propertyString.writeln('  }');
       }
     });

--- a/lib/src/generated_googleapis/src/common_internal.dart
+++ b/lib/src/generated_googleapis/src/common_internal.dart
@@ -69,7 +69,7 @@ class ApiRequester {
         if (stringStream != null) {
           return stringStream.join('').then((String bodyString) {
             if (bodyString == '') return null;
-            return JSON.decode(bodyString);
+            return json.decode(bodyString);
           });
         } else {
           throw new common_external.ApiRequestError(
@@ -186,7 +186,7 @@ class ApiRequester {
       var length = 0;
       var bodyController = new StreamController<List<int>>();
       if (body != null) {
-        var bytes = UTF8.encode(body);
+        var bytes = utf8.encode(body);
         bodyController.add(bytes);
         length = bytes.length;
       }
@@ -259,7 +259,7 @@ class MultipartMediaUploader {
 
   Future<http.StreamedResponse> upload() {
     var base64MediaStream =
-        _uploadMedia.stream.transform(_base64Encoder).transform(ASCII.encoder);
+        _uploadMedia.stream.transform(_base64Encoder).transform(ascii.encoder);
     var base64MediaStreamLength =
         Base64Encoder.lengthOfBase64Stream(_uploadMedia.length);
 
@@ -278,9 +278,9 @@ class MultipartMediaUploader {
         bodyHead.length + base64MediaStreamLength + bodyTail.length;
 
     var bodyController = new StreamController<List<int>>();
-    bodyController.add(UTF8.encode(bodyHead));
+    bodyController.add(utf8.encode(bodyHead));
     bodyController.addStream(base64MediaStream).then((_) {
-      bodyController.add(UTF8.encode(bodyTail));
+      bodyController.add(utf8.encode(bodyTail));
     }).catchError((error, stack) {
       bodyController.addError(error, stack);
     }).then((_) {
@@ -300,7 +300,7 @@ class MultipartMediaUploader {
 }
 
 /// Base64 encodes a stream of bytes.
-class Base64Encoder implements StreamTransformer<List<int>, String> {
+class Base64Encoder extends StreamTransformerBase<List<int>, String> {
   static int lengthOfBase64Stream(int lengthOfByteStream) {
     return ((lengthOfByteStream + 2) ~/ 3) * 4;
   }
@@ -330,7 +330,7 @@ class Base64Encoder implements StreamTransformer<List<int>, String> {
 
       // Convert & Send bytes from buffer (if necessary).
       if (remainingBytes.length > 0) {
-        controller.add(BASE64.encode(remainingBytes));
+        controller.add(base64.encode(remainingBytes));
         remainingBytes.clear();
       }
 
@@ -340,9 +340,9 @@ class Base64Encoder implements StreamTransformer<List<int>, String> {
       // Convert & Send main bytes.
       if (start == 0 && end == bytes.length) {
         // Fast path if [bytes] are devisible by 3.
-        controller.add(BASE64.encode(bytes));
+        controller.add(base64.encode(bytes));
       } else {
-        controller.add(BASE64.encode(bytes.sublist(start, end)));
+        controller.add(base64.encode(bytes.sublist(start, end)));
 
         // Buffer remaining bytes if necessary.
         if (end < bytes.length) {
@@ -357,7 +357,7 @@ class Base64Encoder implements StreamTransformer<List<int>, String> {
 
     void onDone() {
       if (remainingBytes.length > 0) {
-        controller.add(BASE64.encode(remainingBytes));
+        controller.add(base64.encode(remainingBytes));
         remainingBytes.clear();
       }
       controller.close();
@@ -479,7 +479,7 @@ class ResumableMediaUploader {
     var length = 0;
     var bytes;
     if (_body != null) {
-      bytes = UTF8.encode(_body);
+      bytes = utf8.encode(_body);
       length = bytes.length;
     }
     var bodyStream = _bytes2Stream(bytes);
@@ -798,7 +798,7 @@ Future<http.StreamedResponse> _validateResponse(
     // Some error happened, try to decode the response and fetch the error.
     Stream<String> stringStream = _decodeStreamAsText(response);
     if (stringStream != null) {
-      return stringStream.transform(JSON.decoder).first.then((json) {
+      return stringStream.transform(json.decoder).first.then((json) {
         if (json is Map && json['error'] is Map) {
           var error = json['error'];
           var code = error['code'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,11 @@ description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator
 
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=2.0.0-dev.22.0 <2.0.0'
 
 dependencies:
   args: '>=0.12.1 <2.0.0'
-  dart_style: '>=1.0.7 <=1.0.9+1'
+  dart_style: '>=1.0.7 <=2.0.0'
   http: '>=0.11.1 <0.12.0'
   path: '>=1.3.3 <2.0.0'
   yaml: '>=2.0.0 <3.0.0'

--- a/test/src/dart_schemas_test.dart
+++ b/test/src/dart_schemas_test.dart
@@ -505,13 +505,13 @@ main() {
 
           // Array simple/complex
           expect(unNamedArraySimple.needsJsonEncoding, false);
-          expect(unNamedArraySimple.needsJsonDecoding, false);
+          expect(unNamedArraySimple.needsJsonDecoding, true);
           expect(unNamedArrayComplex.needsJsonEncoding, true);
           expect(unNamedArrayComplex.needsJsonDecoding, true);
 
           // Map simple/complex
           expect(unNamedMapSimple.needsJsonEncoding, false);
-          expect(unNamedMapSimple.needsJsonDecoding, false);
+          expect(unNamedMapSimple.needsJsonDecoding, true);
           expect(unNamedMapComplex.needsJsonEncoding, true);
           expect(unNamedMapComplex.needsJsonDecoding, true);
 

--- a/test/src/data/expected_identical.dartt
+++ b/test/src/data/expected_identical.dartt
@@ -121,7 +121,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(
+      _body = convert.json.encode(
           request.map((value) => ToyRequestFactory.toJson(value)).toList());
     }
     if ($fields != null) {
@@ -136,11 +136,9 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) =>
-        commons.mapMap<core.Map<core.String, core.Object>, ToyResponse>(
-            data,
-            (core.Map<core.String, core.Object> item) =>
-                ToyResponseFactory.fromJson(item)));
+    return _response.then((data) => commons.mapMap<core.Map, ToyResponse>(
+        data.cast<core.String, core.Map>(),
+        (core.Map item) => ToyResponseFactory.fromJson(item)));
   }
 
   /// [request] - The metadata request object.
@@ -168,7 +166,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request
+      _body = convert.json.encode(request
           .map((value) =>
               value.map((value) => ToyRequestFactory.toJson(value)).toList())
           .toList());
@@ -185,11 +183,9 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) =>
-        commons.mapMap<core.Map<core.String, core.Object>, ToyResponse>(
-            data,
-            (core.Map<core.String, core.Object> item) =>
-                ToyResponseFactory.fromJson(item)));
+    return _response.then((data) => commons.mapMap<core.Map, ToyResponse>(
+        data.cast<core.String, core.Map>(),
+        (core.Map item) => ToyResponseFactory.fromJson(item)));
   }
 
   /// [request] - The metadata request object.
@@ -217,7 +213,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -231,7 +227,8 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => data);
+    return _response
+        .then((data) => (data as core.Map).cast<core.String, core.int>());
   }
 
   /// Request parameters:
@@ -310,7 +307,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(ToyAgeRequestFactory.toJson(request));
+      _body = convert.json.encode(ToyAgeRequestFactory.toJson(request));
     }
     if (name == null) {
       throw new core.ArgumentError("Parameter name is required.");
@@ -406,7 +403,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -420,7 +417,10 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => data);
+    return _response.then((data) => (data as core.List)
+        .map<core.List<core.String>>(
+            (value) => (value as core.List).cast<core.String>())
+        .toList());
   }
 
   /// [request] - The metadata request object.
@@ -450,7 +450,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -464,7 +464,12 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => data);
+    return _response.then((data) => (data as core.List)
+        .map<core.Map<core.String, core.List<core.String>>>((value) =>
+            commons.mapMap<core.List, core.List<core.String>>(
+                value.cast<core.String, core.List>(),
+                (core.List item) => (item as core.List).cast<core.String>()))
+        .toList());
   }
 
   /// Request parameters:
@@ -530,7 +535,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -544,7 +549,13 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => data);
+    return _response.then((data) =>
+        commons.mapMap<core.List, core.List<core.Map<core.String, core.bool>>>(
+            data.cast<core.String, core.List>(),
+            (core.List item) => (item as core.List)
+                .map<core.Map<core.String, core.bool>>((value) =>
+                    (value as core.Map).cast<core.String, core.bool>())
+                .toList()));
   }
 
   /// [request] - The metadata request object.
@@ -574,7 +585,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -588,7 +599,11 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => data);
+    return _response.then((data) =>
+        commons.mapMap<core.Map, core.Map<core.String, core.bool>>(
+            data.cast<core.String, core.Map>(),
+            (core.Map item) =>
+                (item as core.Map).cast<core.String, core.bool>()));
   }
 
   /// [request] - The metadata request object.
@@ -615,7 +630,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(ToyRequestFactory.toJson(request));
+      _body = convert.json.encode(ToyRequestFactory.toJson(request));
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -762,7 +777,7 @@ class ToyApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -776,7 +791,7 @@ class ToyApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => data);
+    return _response.then((data) => (data as core.List).cast<core.String>());
   }
 }
 
@@ -932,11 +947,9 @@ class ToyMapResponseFactory {
   static ToyMapResponse fromJson(core.Map _json) {
     var message = new ToyMapResponse();
     if (_json.containsKey("mapResult")) {
-      message.mapResult =
-          commons.mapMap<core.Map<core.String, core.Object>, NestedResponse>(
-              _json["mapResult"],
-              (core.Map<core.String, core.Object> item) =>
-                  NestedResponseFactory.fromJson(item));
+      message.mapResult = commons.mapMap<core.Map, NestedResponse>(
+          _json["mapResult"].cast<core.String, core.Map>(),
+          (core.Map item) => NestedResponseFactory.fromJson(item));
     }
     if (_json.containsKey("result")) {
       message.result = _json["result"];

--- a/test/src/data/expected_nonidentical.dartt
+++ b/test/src/data/expected_nonidentical.dartt
@@ -121,7 +121,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -163,7 +163,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -203,7 +203,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -296,7 +296,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
     if (name == null) {
       throw new core.ArgumentError("Parameter name is required.");
@@ -391,7 +391,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -433,7 +433,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -510,7 +510,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -551,7 +551,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -592,7 +592,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode((request).toJson());
+      _body = convert.json.encode((request).toJson());
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -738,7 +738,7 @@ class ToyApiApi {
     var _body = null;
 
     if (request != null) {
-      _body = convert.JSON.encode(request);
+      _body = convert.json.encode(request);
     }
     if ($fields != null) {
       _queryParams["fields"] = [$fields];
@@ -874,7 +874,9 @@ class ListOfListOfString extends collection.ListBase<core.List<core.String>> {
   ListOfListOfString() : _inner = [];
 
   ListOfListOfString.fromJson(core.List json)
-      : _inner = json.map((value) => value).toList();
+      : _inner = json
+            .map((value) => (value as core.List).cast<core.String>())
+            .toList();
 
   core.List<core.List<core.String>> toJson() {
     return _inner.map((value) => value).toList();
@@ -901,8 +903,9 @@ class ListOfListOfToyRequest
 
   ListOfListOfToyRequest.fromJson(core.List json)
       : _inner = json
-            .map((value) =>
-                value.map<ToyRequest>((value) => new ToyRequest.fromJson(value)).toList())
+            .map((value) => (value as core.List)
+                .map<ToyRequest>((value) => new ToyRequest.fromJson(value))
+                .toList())
             .toList();
 
   core.List<core.List<core.Map<core.String, core.Object>>> toJson() {
@@ -930,7 +933,8 @@ class ListOfListOfint extends collection.ListBase<core.List<core.int>> {
   ListOfListOfint() : _inner = [];
 
   ListOfListOfint.fromJson(core.List json)
-      : _inner = json.map((value) => value).toList();
+      : _inner =
+            json.map((value) => (value as core.List).cast<core.int>()).toList();
 
   core.List<core.List<core.int>> toJson() {
     return _inner.map((value) => value).toList();
@@ -956,7 +960,11 @@ class ListOfMapOfListOfString
   ListOfMapOfListOfString() : _inner = [];
 
   ListOfMapOfListOfString.fromJson(core.List json)
-      : _inner = json.map((value) => value).toList();
+      : _inner = json
+            .map((value) => commons.mapMap<core.List, core.List<core.String>>(
+                value.cast<core.String, core.List>(),
+                (core.List item) => (item as core.List).cast<core.String>()))
+            .toList();
 
   core.List<core.Map<core.String, core.List<core.String>>> toJson() {
     return _inner.map((value) => value).toList();
@@ -984,7 +992,11 @@ class ListOfMapOfListOfint
   ListOfMapOfListOfint() : _inner = [];
 
   ListOfMapOfListOfint.fromJson(core.List json)
-      : _inner = json.map((value) => value).toList();
+      : _inner = json
+            .map((value) => commons.mapMap<core.List, core.List<core.int>>(
+                value.cast<core.String, core.List>(),
+                (core.List item) => (item as core.List).cast<core.int>()))
+            .toList();
 
   core.List<core.Map<core.String, core.List<core.int>>> toJson() {
     return _inner.map((value) => value).toList();
@@ -1057,13 +1069,17 @@ class ListOfToyRequest extends collection.ListBase<ToyRequest> {
 
 class MapOfListOfMapOfbool extends collection
     .MapBase<core.String, core.List<core.Map<core.String, core.bool>>> {
-  final core.Map _innerMap = {};
+  final _innerMap =
+      <core.String, core.List<core.Map<core.String, core.bool>>>{};
 
   MapOfListOfMapOfbool();
 
   MapOfListOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
-      this[key] = value;
+      this[key] = (value as core.List)
+          .map<core.Map<core.String, core.bool>>(
+              (value) => (value as core.Map).cast<core.String, core.bool>())
+          .toList();
     });
   }
 
@@ -1096,13 +1112,16 @@ class MapOfListOfMapOfbool extends collection
 
 class MapOfListOfMapOfint extends collection
     .MapBase<core.String, core.List<core.Map<core.String, core.int>>> {
-  final core.Map _innerMap = {};
+  final _innerMap = <core.String, core.List<core.Map<core.String, core.int>>>{};
 
   MapOfListOfMapOfint();
 
   MapOfListOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
-      this[key] = value;
+      this[key] = (value as core.List)
+          .map<core.Map<core.String, core.int>>(
+              (value) => (value as core.Map).cast<core.String, core.int>())
+          .toList();
     });
   }
 
@@ -1135,13 +1154,13 @@ class MapOfListOfMapOfint extends collection
 
 class MapOfMapOfbool
     extends collection.MapBase<core.String, core.Map<core.String, core.bool>> {
-  final core.Map _innerMap = {};
+  final _innerMap = <core.String, core.Map<core.String, core.bool>>{};
 
   MapOfMapOfbool();
 
   MapOfMapOfbool.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
-      this[key] = value;
+      this[key] = (value as core.Map).cast<core.String, core.bool>();
     });
   }
 
@@ -1173,13 +1192,13 @@ class MapOfMapOfbool
 
 class MapOfMapOfint
     extends collection.MapBase<core.String, core.Map<core.String, core.int>> {
-  final core.Map _innerMap = {};
+  final _innerMap = <core.String, core.Map<core.String, core.int>>{};
 
   MapOfMapOfint();
 
   MapOfMapOfint.fromJson(core.Map<core.String, core.dynamic> _json) {
     _json.forEach((core.String key, value) {
-      this[key] = value;
+      this[key] = (value as core.Map).cast<core.String, core.int>();
     });
   }
 
@@ -1210,7 +1229,7 @@ class MapOfMapOfint
 }
 
 class MapOfToyResponse extends collection.MapBase<core.String, ToyResponse> {
-  final core.Map _innerMap = {};
+  final _innerMap = <core.String, ToyResponse>{};
 
   MapOfToyResponse();
 
@@ -1245,7 +1264,7 @@ class MapOfToyResponse extends collection.MapBase<core.String, ToyResponse> {
 }
 
 class MapOfint extends collection.MapBase<core.String, core.int> {
-  final core.Map _innerMap = {};
+  final _innerMap = <core.String, core.int>{};
 
   MapOfint();
 
@@ -1328,11 +1347,9 @@ class ToyMapResponse {
 
   ToyMapResponse.fromJson(core.Map _json) {
     if (_json.containsKey("mapResult")) {
-      mapResult =
-          commons.mapMap<core.Map<core.String, core.Object>, NestedResponse>(
-              _json["mapResult"],
-              (core.Map<core.String, core.Object> item) =>
-                  new NestedResponse.fromJson(item));
+      mapResult = commons.mapMap<core.Map, NestedResponse>(
+          _json["mapResult"].cast<core.String, core.Map>(),
+          (core.Map item) => new NestedResponse.fromJson(item));
     }
     if (_json.containsKey("result")) {
       result = _json["result"];


### PR DESCRIPTION
Updated pubspec to required Dart 2 SDK. The generated code needs to use
.cast() to be fully Dart 2 compliant, so it's no longer feasible to
support Dart 1.

Updated code to stop using screaming consts.

Fixes #189.