### PR TITLE
Call toDouble() in generated code

### DIFF
--- a/lib/src/dart_schemas.dart
+++ b/lib/src/dart_schemas.dart
@@ -104,6 +104,8 @@ class BoolJsonType extends SimpleJsonType {
 
 class DoubleJsonType extends SimpleJsonType {
   DoubleJsonType(DartApiImports imports) : super(imports, 'double');
+
+  String get baseDeclaration => '${imports.core.ref()}num';
 }
 
 class MapJsonType extends JsonType {
@@ -298,6 +300,7 @@ class DoubleType extends PrimitiveDartSchemaType {
         super(imports);
 
   String get declaration => '${imports.core.ref()}double';
+  String jsonDecode(String json) => '$json.toDouble()';
 }
 
 class StringType extends PrimitiveDartSchemaType {

--- a/test/src/dart_schemas_test.dart
+++ b/test/src/dart_schemas_test.dart
@@ -454,7 +454,7 @@ main() {
           expect(db.integerType.needsJsonEncoding, false);
           expect(db.integerType.needsJsonDecoding, false);
           expect(db.doubleType.needsJsonEncoding, false);
-          expect(db.doubleType.needsJsonDecoding, false);
+          expect(db.doubleType.needsJsonDecoding, true);
           expect(db.booleanType.needsJsonEncoding, false);
           expect(db.booleanType.needsJsonDecoding, false);
           expect(db.dateType.needsJsonEncoding, true);


### PR DESCRIPTION
This is the first step to fix: https://github.com/dart-lang/googleapis/issues/11

The generated code is now like: 
```dart
if (_json.containsKey("property")) {
  property = _json["property"].toDouble();
}

// and

properties = commons.mapMap<core.num, core.double>(
    _json["properties"].cast<core.String, core.num>(),
     (core.num item) => item.toDouble());

```

