### PR TITLE
Bump _discoveryapis_commons to allow 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - discoveryapis_generator
 
+## v0.9.14
+ - Bumped `_discoveryapis_commons` to allow `0.2.x`.
+
 ## v0.9.12
 
 - Fixed suggestions from pana in the generated code.

--- a/lib/discoveryapis_generator.dart
+++ b/lib/discoveryapis_generator.dart
@@ -30,7 +30,7 @@ class Pubspec {
 
   static Map<String, Object> get dependencies => const {
         'http': '\'>=0.11.1 <0.13.0\'',
-        '_discoveryapis_commons': '\'>=0.1.0 <0.2.0\'',
+        '_discoveryapis_commons': '\'>=0.1.0 <0.3.0\'',
       };
 
   static Map<String, Object> get devDependencies => const {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: discoveryapis_generator
-version: 0.9.13-dev
+version: 0.9.14
 author: Dart Team <misc@dartlang.org>
 description: Create API Client libraries based on the Discovery API Service.
 homepage: https://github.com/dart-lang/discoveryapis_generator
@@ -15,7 +15,7 @@ dependencies:
   yaml: ^2.0.0
 
 dev_dependencies:
-  _discoveryapis_commons: ^0.1.0
+  _discoveryapis_commons: ^0.2.0
   test: ^1.0.0
 
 executables:


### PR DESCRIPTION
Already tested with:
```yaml
dependency_overrides:
  _discoveryapis_commons:
    git:
      url: https://github.com/jonasfj/discoveryapis_commons
      ref: implement-exception-not-error
```

So this should be good to go once that lands.