### PR TITLE
Add null safety support.

### DIFF
--- a/discoveryapis_generator/lib/discoveryapis_generator.dart
+++ b/discoveryapis_generator/lib/discoveryapis_generator.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 import 'src/apis_files_generator.dart';
 import 'src/apis_package_generator.dart';
 import 'src/generated_googleapis/discovery/v1.dart';
+import 'src/null_safety.dart' as null_safety;
 import 'src/utils.dart';
 
 export 'src/generated_googleapis/discovery/v1.dart';
@@ -47,7 +48,10 @@ List<GenerateResult> generateApiPackage(List<RestDescription> descriptions,
 }
 
 List<GenerateResult> generateAllLibraries(
-    String inputDirectory, String outputDirectory, Pubspec pubspec) {
+    String inputDirectory, String outputDirectory, Pubspec pubspec,
+    {bool generateNullSafe = false}) {
+  null_safety.generateNullSafeCode = generateNullSafe;
+
   var apiDescriptions = Directory(inputDirectory)
       .listSync()
       .where((fse) => fse is File && fse.path.endsWith('.json'))

--- a/discoveryapis_generator/lib/src/null_safety.dart
+++ b/discoveryapis_generator/lib/src/null_safety.dart
@@ -1,0 +1,12 @@
+/// Whether to generate null safe code.
+bool generateNullSafeCode = false;
+
+/// String representing `?` in optionally-null-safe code.
+///
+/// If generating null safe code, returns `?`. Otherwise returns ``.
+String get orNull => generateNullSafeCode ? '?' : '';
+
+/// String representing `!` in optionally-null-safe code.
+///
+/// If generating null safe code, returns `!`. Otherwise returns ``.
+String get notNull => generateNullSafeCode ? '!' : '';


### PR DESCRIPTION
Null safety support is behind a boolean flag; legacy generation is unchanged.

I think the right path for this is to prove it in google3 before any external release, so I have not mentioned in CHANGELOG. We will however need to publish it to depend on it from `package:googleapis`.